### PR TITLE
Handling of special 0x0F mIRC color reset attribute

### DIFF
--- a/weechat-relay/junit/com/ubergeek42/weechat/ColorTest.java
+++ b/weechat-relay/junit/com/ubergeek42/weechat/ColorTest.java
@@ -12,13 +12,33 @@ public class ColorTest {
 		String oracle = "asd";
 		assertEquals(oracle, Color.stripColors(teststr));
 	}
+
+    /**
+     *  0x0F is ascii character 15, which turns off all previous attributes, including color, bold, underline and italics.
+     *  This case happens on freenode with title set to something containing colors, the 0F seems to come from what
+     *  should be 0x1C, or reset colors/attributes. See <a href="http://www.mirc.com/colors.html">mIRC Colors</a>.
+     *
+     *
+     *  warning : it shouldn't really be stripped away, but due to performance reasons we don't want to run every
+     *  BufferLine through Color.stripAllColorsAndAttributes().
+     *  Make this unit test fail in the future if it causes issues!
+     */
 	@Test
-	public void testStripColors2() {
-		// Happens on freenode with title set to something containing colors, the 0F seems to come from what should be 0x1C, or reset colors/attributes
+	public void testStrip0x0FwithWeeChatStyle() {
 		String teststr = "red green cyan.\u000F some normal text";
 		String oracle = "red green cyan. some normal text";
 		assertEquals(oracle, Color.stripColors(teststr));
 	}
+    /**
+     *  0x0F is ascii character 15, which turns off all previous attributes, including color, bold, underline and italics.
+     *  See <a href="http://www.mirc.com/colors.html">mIRC Colors</a>
+     */
+    @Test
+    public void testStrip0x0FwithIRCStyle() {
+        String teststr = "red green cyan.\u000F some normal text";
+        String oracle = "red green cyan. some normal text";
+        assertEquals(oracle, Color.stripIRCColors(teststr));
+    }
     @Test
     public void testStripColorInIset() {
         String isetTitle = "Interactive set (iset.pl v1.0)  |  Filter: \u0019F08*relay*\u0019F00  |  16 options";

--- a/weechat-relay/src/com/ubergeek42/weechat/Color.java
+++ b/weechat-relay/src/com/ubergeek42/weechat/Color.java
@@ -332,7 +332,16 @@ public class Color {
 					}
 					if (insert_html) { parsedMsg.append(getHTMLTag()); }
 				}
-			} else {
+			} else if (peekChar()==0x0F) { // warning: see unit test testStrip0x0FwithWeeChatStyle() in ColorTest (weechat-relay)
+                getChar();
+                fgColor = FG_DEFAULT;
+                bgColor = BG_DEFAULT;
+                reverse = false;
+                italic = false;
+                underline = false;
+                if (insert_html) { parsedMsg.append(getHTMLTag()); }
+                continue;
+            } else {
 				// Not formatting or anything, so append it to the string
 				parsedMsg.append(getChar());
 			}


### PR DESCRIPTION
Due to performance reasons, this also gets stripped in the WeeChat stripColors() method. Note added in both unit test and Color class.
