### PR TITLE
Only load buffer from intent when bundle has key

### DIFF
--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/WeechatActivity.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/WeechatActivity.java
@@ -168,7 +168,7 @@ public class WeechatActivity extends SherlockFragmentActivity implements RelayCo
     private void handleIntent() {
         // Load a buffer if necessary
         Bundle extras = getIntent().getExtras();
-        if (extras != null) {
+        if (extras != null && extras.containsKey("buffer")) {
             // Load the given buffer
             onBufferSelected(extras.getString("buffer"));
         } else {


### PR DESCRIPTION
- Android 4.4.4 sends a bundle when launching weechat-android from the homescreen and the app is already running.
