### PR TITLE
Add TCP keepalive

### DIFF
--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/WeechatPreferencesActivity.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/WeechatPreferencesActivity.java
@@ -42,6 +42,9 @@ public class WeechatPreferencesActivity extends PreferenceActivity implements
     private EditTextPreference sshPassPref;
     private EditTextPreference sshUserPref;
     private EditTextPreference sshKeyFilePref;
+    private EditTextPreference tcpKeepIdlePref;
+    private EditTextPreference tcpKeepIntervalPref;
+    private EditTextPreference tcpKeepCountPref;
     private ListPreference prefixPref;
     private ListPreference connectionTypePref;
 
@@ -80,6 +83,10 @@ public class WeechatPreferencesActivity extends PreferenceActivity implements
         sshPassPref = (EditTextPreference) getPreferenceScreen().findPreference("ssh_pass");
         sshKeyFilePref = (EditTextPreference) getPreferenceScreen().findPreference("ssh_keyfile");
 
+        tcpKeepIdlePref = (EditTextPreference) getPreferenceScreen().findPreference("tcp_keepidle");
+        tcpKeepIntervalPref = (EditTextPreference) getPreferenceScreen().findPreference("tcp_keepintvl");
+        tcpKeepCountPref = (EditTextPreference) getPreferenceScreen().findPreference("tcp_keepcnt");
+
         prefixPref = (ListPreference) getPreferenceScreen().findPreference("prefix_align");
         connectionTypePref = (ListPreference) getPreferenceScreen().findPreference("connection_type");
         setTitle(R.string.preferences);
@@ -107,6 +114,10 @@ public class WeechatPreferencesActivity extends PreferenceActivity implements
         sshUserPref.setSummary(sharedPreferences.getString("ssh_user", ""));
         sshPortPref.setSummary(sharedPreferences.getString("ssh_port", "22"));
         sshKeyFilePref.setSummary(sharedPreferences.getString("ssh_keyfile", "Not Set"));
+
+        tcpKeepIdlePref.setSummary(sharedPreferences.getString("tcp_keepidle", "60"));
+        tcpKeepIntervalPref.setSummary(sharedPreferences.getString("tcp_keepintvl", "15"));
+        tcpKeepCountPref.setSummary(sharedPreferences.getString("tcp_keepcnt", "12"));
 
         prefixPref.setSummary(prefixPref.getEntry());
         connectionTypePref.setSummary(connectionTypePref.getEntry());
@@ -174,6 +185,12 @@ public class WeechatPreferencesActivity extends PreferenceActivity implements
             }
         } else if (key.equals("ssh_keyfile")) {
             sshKeyFilePref.setSummary(sharedPreferences.getString(key, "/sdcard/weechat/sshkey.id_rsa"));
+        } else if (key.equals("tcp_keepidle")) {
+            tcpKeepIdlePref.setSummary(sharedPreferences.getString("tcp_keepidle", "60"));
+        } else if (key.equals("tcp_keepintvl")) {
+            tcpKeepIntervalPref.setSummary(sharedPreferences.getString("tcp_keepintvl", "15"));
+        } else if (key.equals("tcp_keepcnt")) {
+            tcpKeepCountPref.setSummary(sharedPreferences.getString("tcp_keepcnt", "12"));
         } else if (key.equals("prefix_align")) {
             prefixPref.setSummary(prefixPref.getEntry());
         } else if (key.equals("connection_type")) {

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/RelayServiceBackbone.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/RelayServiceBackbone.java
@@ -16,6 +16,7 @@
 package com.ubergeek42.WeechatAndroid.service;
 
 import java.io.File;
+import java.net.Socket;
 import java.security.cert.X509Certificate;
 import java.util.HashSet;
 import java.util.List;
@@ -83,6 +84,11 @@ public abstract class RelayServiceBackbone extends Service implements RelayConne
     final static private String PREF_HOST = "host";
     final static private String PREF_PASSWORD = "password";
     final static private String PREF_PORT = "port";
+
+    final static private String PREF_TCP_KEEPALIVE = "tcp_keepalive";
+    final static private String PREF_TCP_KEEPIDLE = "tcp_keepidle";
+    final static private String PREF_TCP_KEEPINTVL = "tcp_keepintvl";
+    final static private String PREF_TCP_KEEPCNT = "tcp_keepcnt";
 
     final static private String PREF_STUNNEL_CERT = "stunnel_cert";
     final static private String PREF_STUNNEL_PASS = "stunnel_pass";
@@ -503,6 +509,14 @@ public abstract class RelayServiceBackbone extends Service implements RelayConne
     @Override
     public void onConnect() {
         if (DEBUG) logger.debug("onConnect()");
+        Socket tcpSock = connection.getTCPSocket();
+        if (tcpSock != null) {
+            if (prefs.getBoolean(PREF_TCP_KEEPALIVE, true))
+                TCPKeepAlive.configureKeepAlive(tcpSock,
+                    Integer.parseInt(prefs.getString(PREF_TCP_KEEPIDLE, "60")),
+                    Integer.parseInt(prefs.getString(PREF_TCP_KEEPINTVL, "15")),
+                    Integer.parseInt(prefs.getString(PREF_TCP_KEEPCNT, "12")));
+        }
         connection_status = CONNECTED;
         for (RelayConnectionHandler rch : connectionHandlers) rch.onConnect();
     }

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/TCPKeepAlive.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/TCPKeepAlive.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright 2014 Simon Arlott
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+package com.ubergeek42.WeechatAndroid.service;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Field;
+import java.io.FileDescriptor;
+import java.net.Socket;
+import java.net.SocketException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class TCPKeepAlive {
+    private static final Logger logger = LoggerFactory.getLogger("KeepAlive");
+
+    /* These definitions are only valid on Linux */
+    private static final int IPPROTO_TCP = 6;
+    private static final int TCP_KEEPIDLE = 4;
+    private static final int TCP_KEEPINTVL = 5;
+    private static final int TCP_KEEPCNT = 6;
+
+    private static Object os;
+    private static Method setsockoptInt;
+
+    static {
+        try {
+            String osName =  System.getProperty("os.name");
+            if (osName.equals("Linux")) {
+               Class libcore = Class.forName("libcore.io.Libcore");
+               Field osField = libcore.getDeclaredField("os");
+               osField.setAccessible(true);
+
+               os = osField.get(null);
+               setsockoptInt = osField.getType().getDeclaredMethod("setsockoptInt", FileDescriptor.class, int.class, int.class, int.class);
+               setsockoptInt.setAccessible(true);
+               logger.info("TCP keepalive available");
+            } else {
+                logger.warn("OS={}", osName);
+            }
+        } catch (Throwable t) {
+            logger.warn("Unable to get setsockoptInt()", t);
+        }
+    }
+
+    static boolean configureKeepAlive(Socket s, int idle, int interval, int count) {
+        try {
+            s.setKeepAlive(true);
+        } catch (SocketException e) {
+            logger.error("Unable to enable TCP keepalive on socket {}", s, e);
+            return false;
+        }
+
+        if (setsockoptInt == null)
+            return false;
+
+        FileDescriptor fd = getFileDescriptor(s);
+        if (fd == null) {
+            logger.error("No FileDescriptor for socket {}", s);
+            return false;
+        }
+
+        try {
+            setsockoptInt.invoke(os, fd, IPPROTO_TCP, TCP_KEEPIDLE, idle);
+            setsockoptInt.invoke(os, fd, IPPROTO_TCP, TCP_KEEPINTVL, interval);
+            setsockoptInt.invoke(os, fd, IPPROTO_TCP, TCP_KEEPCNT, count);
+            logger.info("Configured TCP keepalive on socket {}", s);
+            return true;
+        } catch (Throwable t) {
+            logger.error("Unable to configure TCP keepalive on socket {}", s, t);
+            return false;
+        }
+    }
+
+    private static FileDescriptor getFileDescriptor(Socket s) {
+        try {
+            Method getFileDescriptor = s.getClass().getDeclaredMethod("getFileDescriptor$");
+            getFileDescriptor.setAccessible(true);
+            return (FileDescriptor)getFileDescriptor.invoke(s);
+        } catch (Throwable t) {
+            logger.warn("Unable to get FileDescriptor using getFileDescriptor$()", t);
+        }
+
+        logger.warn("Unable to get FileDescriptor for {}", s.getClass());
+        return null;
+    }
+}

--- a/weechat-android/src/main/res/values/strings.xml
+++ b/weechat-android/src/main/res/values/strings.xml
@@ -71,6 +71,14 @@
 		    <string name="pref_ssh_port">SSH port</string>
 		    <string name="pref_ssh_pass">SSH password/key passphrase</string>
 		    <string name="pref_ssh_keyfile">SSH private key file</string>
+	    <string name="pref_tcp_keepalive_group">TCP Keepalive settings</string>
+		    <string name="pref_tcp_keepalive">Enable TCP Keepalive</string>
+		    <string name="pref_tcp_keepidle">Idle time</string>
+		    <string name="pref_tcp_keepidle_summary">Idle time with no data before sending a keepalive probe</string>
+		    <string name="pref_tcp_keepintvl">Transmit interval</string>
+		    <string name="pref_tcp_keepintvl_summary">Interval at which to transmit subsequent keepalive probes when there is no response</string>
+		    <string name="pref_tcp_keepcnt">Retry count</string>
+		    <string name="pref_tcp_keepcnt_summary">Maximum number of unacknowledged keepalive probes before closing the connection</string>
     <string name="pref_bufferlist_group">Buffer list settings</string>
 	    <string name="pref_sort_buffers">Sort buffer list</string>
 	    <string name="pref_sort_buffers_summary">Sort by number of highlights/private messages/unread messages</string>

--- a/weechat-android/src/main/res/xml/preferences.xml
+++ b/weechat-android/src/main/res/xml/preferences.xml
@@ -25,6 +25,13 @@
 				<EditTextPreference android:key="ssh_pass" android:title="@string/pref_ssh_pass" android:password="true" android:singleLine="true"/>
 				<EditTextPreference android:key="ssh_keyfile" android:title="@string/pref_ssh_keyfile" android:singleLine="true" android:summary="/sdcard/weechat/sshkey.id_rsa" />
 			</PreferenceScreen>
+
+			<PreferenceScreen android:key="tcp_keepalive_group" android:title="@string/pref_tcp_keepalive_group">
+				<CheckBoxPreference android:key="tcp_keepalive" android:title="@string/pref_tcp_keepalive" android:defaultValue="true" />
+				<EditTextPreference android:key="tcp_keepidle" android:title="@string/pref_tcp_keepidle" android:summary="@string/pref_tcp_keepidle_summary" android:numeric="integer" android:defaultValue="60" />
+				<EditTextPreference android:key="tcp_keepintvl" android:title="@string/pref_tcp_keepintvl" android:summary="@string/pref_tcp_keepintvl_summary" android:numeric="integer" android:defaultValue="12" />
+				<EditTextPreference android:key="tcp_keepcnt" android:title="@string/pref_tcp_keepcnt" android:summary="@string/pref_tcp_keepcnt_summary" android:numeric="integer" android:defaultValue="12" />
+			</PreferenceScreen>
 		</PreferenceCategory>
     </PreferenceScreen>
 

--- a/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/RelayConnection.java
+++ b/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/RelayConnection.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.Socket;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -66,6 +67,11 @@ public class RelayConnection implements RelayConnectionHandler {
 
     public String getServer() {
         return "Weechat Server(Placeholder)";
+    }
+
+    /* Exposed for additional configuration (keepalive), may be null */
+    public Socket getTCPSocket() {
+        return conn.getTCPSocket();
     }
 
     public boolean isConnected() {

--- a/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/AbstractConnection.java
+++ b/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/AbstractConnection.java
@@ -20,6 +20,7 @@ public abstract class AbstractConnection implements IConnection {
     int port = 0;
 
     Socket sock = null;
+    Socket tcpSock = null;
     OutputStream out_stream = null;
     InputStream in_stream = null;
     volatile boolean connected = false;
@@ -106,10 +107,17 @@ public abstract class AbstractConnection implements IConnection {
             } catch (IOException e) {}
             sock = null;
         }
+        tcpSock = null;
 
         // Call any registered disconnect handlers
         notifyHandlers(STATE.DISCONNECTED);
     }
+
+    @Override
+    public Socket getTCPSocket() {
+        return tcpSock;
+    }
+
     /**
      * Register a connection handler to receive onConnected/onDisconnected events
      *

--- a/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/IConnection.java
+++ b/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/IConnection.java
@@ -3,6 +3,7 @@ package com.ubergeek42.weechat.relay.connection;
 import com.ubergeek42.weechat.relay.RelayConnectionHandler;
 
 import java.io.IOException;
+import java.net.Socket;
 
 public interface IConnection {
     void addConnectionHandler(RelayConnectionHandler relayConnection);
@@ -19,6 +20,9 @@ public interface IConnection {
     public void disconnect();
 
     public boolean isConnected();
+
+    /* Exposed for additional configuration (keepalive), may be null */
+    public Socket getTCPSocket();
 
     int read(byte[] bytes, int off, int len) throws IOException;
 

--- a/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/PlainConnection.java
+++ b/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/PlainConnection.java
@@ -22,6 +22,7 @@ public class PlainConnection extends AbstractConnection {
                 SocketChannel channel = SocketChannel.open();
                 channel.connect(new InetSocketAddress(server, port));
                 sock = channel.socket();
+                tcpSock = sock;
                 out_stream = sock.getOutputStream();
                 in_stream = sock.getInputStream();
                 connected = true;

--- a/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/SSLConnection.java
+++ b/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/SSLConnection.java
@@ -43,6 +43,7 @@ public class SSLConnection extends AbstractConnection {
                 channel.connect(new InetSocketAddress(server, port));
                 SSLSocketFactory socketFactory = sslContext.getSocketFactory();
                 sock = socketFactory.createSocket(channel.socket(), server, port, true);
+                tcpSock = channel.socket();
 
                 out_stream = sock.getOutputStream();
                 in_stream = sock.getInputStream();

--- a/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/StunnelConnection.java
+++ b/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/StunnelConnection.java
@@ -92,6 +92,7 @@ public class StunnelConnection extends AbstractConnection {
                 SocketChannel channel = SocketChannel.open();
                 channel.connect(new InetSocketAddress(server, port));
                 sock = socketFactory.createSocket(channel.socket(), server, port, true);
+                tcpSock = channel.socket();
                 out_stream = sock.getOutputStream();
                 in_stream = sock.getInputStream();
                 connected = true;


### PR DESCRIPTION
Fixes issue #103 (on Linux devices)

Preferences don't include realtime updates to the current connection,
although that would be possible.