### PR TITLE
Notify user if relay password is wrong

### DIFF
--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/WeechatActivity.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/WeechatActivity.java
@@ -300,7 +300,7 @@ public class WeechatActivity extends SherlockFragmentActivity implements RelayCo
     @Override public void onAuthenticationFailed() {
         runOnUiThread(new Runnable() {
             @Override public void run() {
-                Toast.makeText(getBaseContext(), "Wrong password.", Toast.LENGTH_LONG).show();
+                Toast.makeText(getBaseContext(), getString(R.string.notification_wrong_password), Toast.LENGTH_LONG).show();
             }
         });
     }

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/WeechatActivity.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/WeechatActivity.java
@@ -297,6 +297,14 @@ public class WeechatActivity extends SherlockFragmentActivity implements RelayCo
 
     @Override public void onAuthenticated() {}
 
+    @Override public void onAuthenticationFailed() {
+        runOnUiThread(new Runnable() {
+            @Override public void run() {
+                Toast.makeText(getBaseContext(), "Wrong password.", Toast.LENGTH_LONG).show();
+            }
+        });
+    }
+
     @Override public void onBuffersListed() {
         if (DEBUG_CONNECION) logger.debug("onBuffersListed()");
         adjustUI();

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.java
@@ -217,6 +217,7 @@ public class BufferFragment extends SherlockFragment implements BufferEye, OnKey
     @Override public void onConnecting() {}
     @Override public void onConnect() {}
     @Override public void onAuthenticated() {}
+    @Override public void onAuthenticationFailed() {}
     @Override public void onError(String err, Object extraInfo) {}
 
     public void onBuffersListed() {

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferListFragment.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferListFragment.java
@@ -138,6 +138,7 @@ public class BufferListFragment extends SherlockListFragment implements RelayCon
     @Override public void onConnecting() {}
     @Override public void onConnect() {}
     @Override public void onAuthenticated() {}
+    @Override public void onAuthenticationFailed() {}
     @Override public void onDisconnect() {}
     @Override public void onError(String err, Object extraInfo) {}
 

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/RelayServiceBackbone.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/RelayServiceBackbone.java
@@ -531,6 +531,13 @@ public abstract class RelayServiceBackbone extends Service implements RelayConne
         for (RelayConnectionHandler rch : connectionHandlers) rch.onAuthenticated();
     }
 
+    @Override
+    public void onAuthenticationFailed() {
+        if (DEBUG) logger.debug("onAuthenticateFailed()");
+
+        for (RelayConnectionHandler rch : connectionHandlers) rch.onAuthenticationFailed();
+    }
+
     abstract void startHandlingBoneEvents();
 
     @Override

--- a/weechat-android/src/main/res/values/strings.xml
+++ b/weechat-android/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="notification_upgrading_details">WeeChat is upgrading, please wait for reconnection</string>
     <string name="notification_network_unavailable">Network unavailable</string>
     <string name="notification_network_unavailable_details">Failed to connect, network unavailable</string>
+    <string name="notification_wrong_password">Wrong password</string>
     
     <!-- Preferences -->
     <string name="pref_connection_group">Connection settings</string>

--- a/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/RelayConnectionHandler.java
+++ b/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/RelayConnectionHandler.java
@@ -41,6 +41,12 @@ public interface RelayConnectionHandler {
     public void onAuthenticated();
 
     /**
+     * Called when a connection to the server is established, but connection was aborted before any
+     * received messages. It most likely means that password was wrong.
+     */
+    public void onAuthenticationFailed();
+
+    /**
      * Called when the initial list of buffers has been passed to the relay client. After this
      * method call client can assume normal workflow follows.
      */

--- a/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/AbstractConnection.java
+++ b/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/AbstractConnection.java
@@ -133,6 +133,9 @@ public abstract class AbstractConnection implements IConnection {
                 case AUTHENTICATED:
                     rch.onAuthenticated();
                     break;
+                case AUTHENTICATION_FAILED:
+                    rch.onAuthenticationFailed();
+                    break;
                 case DISCONNECTED:
                     rch.onDisconnect();
                     break;

--- a/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/IConnection.java
+++ b/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/IConnection.java
@@ -11,6 +11,7 @@ public interface IConnection {
         CONNECTING,
         CONNECTED,
         AUTHENTICATED,
+        AUTHENTICATION_FAILED,
         DISCONNECTED,
     }
 


### PR DESCRIPTION
The app now displays a simple toast when it is assumed that the password is wrong. The logic is the same as in glowing bear, assuming the wrong password was the reason for the disconnect. Weechat relay terminates the connection right after checking the init command if the password was bad.
