### PR TITLE
change notification messages from "Hot" to "New"

### DIFF
--- a/weechat-android/src/main/res/values/strings.xml
+++ b/weechat-android/src/main/res/values/strings.xml
@@ -24,8 +24,8 @@
     
     <!-- Some of the notifications the application displays during certain events -->
     <plurals name="hot_messages">
-        <item quantity="one">Hot message!</item>
-        <item quantity="other">%d hot messages</item>
+        <item quantity="one">New message!</item>
+        <item quantity="other">%d new messages</item>
     </plurals>
     <string name="hot_message_not_available">(message not available)</string>
 


### PR DESCRIPTION
"Hot message!" in notification drop down has slightly sexual connotations. If that's the intention, following a particular sense of humor: fine and funny. If not, I am sure I am not the only one who noticed that so that's why I propose a change from "Hot" to (neutral) "New".