### PR TITLE
Distinguish away nicks in nick list using a light blue color

### DIFF
--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/adapters/NickListAdapter.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/adapters/NickListAdapter.java
@@ -1,5 +1,6 @@
 package com.ubergeek42.WeechatAndroid.adapters;
 
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.AlertDialog;
 import android.content.DialogInterface;
 import android.support.annotation.NonNull;
@@ -59,6 +60,8 @@ public class NickListAdapter extends BaseAdapter implements BufferNicklistEye,
 
         Nick nick = getItem(position);
         ((TextView) convertView).setText(nick.prefix + nick.name);
+        if (nick.away)
+            ((TextView) convertView).setTextColor(ContextCompat.getColor(convertView.getContext(), R.color.away_nick));
         return convertView;
     }
 

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/relay/Buffer.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/relay/Buffer.java
@@ -411,9 +411,9 @@ public class Buffer {
     //////////////////////////////////////////////////////////////////////////////////////////////// called by event handlers
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
-    synchronized public void addNick(long pointer, String prefix, String name) {
-        if (DEBUG_NICK) logger.debug("{} addNick({}, {}, {})", shortName, pointer, prefix, name);
-        nicks.add(new Nick(pointer, prefix, name));
+    synchronized public void addNick(long pointer, String prefix, String name, boolean away) {
+        if (DEBUG_NICK) logger.debug("{} addNick({}, {}, {}, {})", shortName, pointer, prefix, name, away);
+        nicks.add(new Nick(pointer, prefix, name, away));
         notifyNicklistChanged();
     }
 
@@ -428,12 +428,13 @@ public class Buffer {
         notifyNicklistChanged();
     }
 
-    synchronized public void updateNick(long pointer, String prefix, String name) {
-        if (DEBUG_NICK) logger.debug("{} updateNick({}, {}, {})", shortName, pointer, prefix, name);
+    synchronized public void updateNick(long pointer, String prefix, String name, boolean away) {
+        if (DEBUG_NICK) logger.debug("{} updateNick({}, {}, {}, {})", shortName, pointer, prefix, name, away);
         for (Nick nick: nicks) {
             if (nick.pointer == pointer) {
                 nick.prefix = prefix;
                 nick.name = name;
+                nick.away = away;
                 break;
             }
         }

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/relay/BufferList.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/relay/BufferList.java
@@ -572,10 +572,11 @@ public class BufferList {
                         long pointer = entry.getPointerLong();
                         String prefix = entry.getItem("prefix").asString();
                         String name = entry.getItem("name").asString();
+                        boolean away = entry.getItem("color").asString().contains("weechat.color.nicklist_away");
                         if (command == ADD)
-                            buffer.addNick(pointer, prefix, name);
+                            buffer.addNick(pointer, prefix, name, away);
                         else
-                            buffer.updateNick(pointer, prefix, name);
+                            buffer.updateNick(pointer, prefix, name, away);
                     }
                 } else if (command == REMOVE) {
                     buffer.removeNick(entry.getPointerLong());

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/relay/Nick.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/relay/Nick.java
@@ -9,10 +9,12 @@ public class Nick {
     public final long pointer;
     public String prefix;
     public String name;
+    public boolean away;
 
-    public Nick(long pointer, String prefix, String name) {
+    public Nick(long pointer, String prefix, String name, boolean away) {
         this.prefix = prefix;
         this.name = name;
         this.pointer = pointer;
+        this.away = away;
     }
 }

--- a/weechat-android/src/main/res/values/style.xml
+++ b/weechat-android/src/main/res/values/style.xml
@@ -73,4 +73,5 @@
     <color name="primary">#FF1B1F22</color>
     <color name="primary_dark">#FF0f1315</color>
     <color name="accent">#ff80cbc4</color>
+    <color name="away_nick">#9cd9f0</color>
 </resources>


### PR DESCRIPTION
This implements the #269 feature request.

Summary:

- adds a new `style.xml` color (a light blue extracted from Glowing Bear)
- parses the `color` nick attribute that contains `[…].nicklist_away` if user is away
- stores the away status (a bool) into a new attribute of class `Nick`
- modifies the `NickListAdapter` to set the color of away nicks