### PR TITLE
[on hold] Implement roles for volume buttons: none, text size, send history

### DIFF
--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
@@ -56,6 +56,8 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
         p.registerOnSharedPreferenceChangeListener(instance = new P());
     }
 
+    public enum VolumeRole {NONE, TEXT_SIZE, SEND_HISTORY}
+
     ///////////////////////////////////////////////////////////////////////////////////////////// ui
 
     public static boolean sortBuffers, showTitle, filterBuffers, optimizeTraffic;
@@ -69,7 +71,8 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
     public static boolean notificationEnable, notificationTicker, notificationLight, notificationVibrate;
     public static String notificationSound;
 
-    public static boolean showSend, showTab, hotlistSync, volumeBtnSize;
+    public static boolean showSend, showTab, hotlistSync;
+    public static VolumeRole volumeRole;
     public static String bufferFont;
 
     public static boolean showBufferFilter;
@@ -102,7 +105,7 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
         showSend = p.getBoolean(PREF_SHOW_SEND, PREF_SHOW_SEND_D);
         showTab = p.getBoolean(PREF_SHOW_TAB, PREF_SHOW_TAB_D);
         hotlistSync = p.getBoolean(PREF_HOTLIST_SYNC, PREF_HOTLIST_SYNC_D);
-        volumeBtnSize = p.getBoolean(PREF_VOLUME_BTN_SIZE, PREF_VOLUME_BTN_SIZE_D);
+        setVolumeBtnRole();
 
         // buffer list filter
         showBufferFilter = p.getBoolean(PREF_SHOW_BUFFER_FILTER, PREF_SHOW_BUFFER_FILTER_D);
@@ -216,7 +219,7 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
             case PREF_SHOW_SEND: showSend = p.getBoolean(key, PREF_SHOW_SEND_D); break;
             case PREF_SHOW_TAB: showTab = p.getBoolean(key, PREF_SHOW_TAB_D); break;
             case PREF_HOTLIST_SYNC: hotlistSync = p.getBoolean(key, PREF_HOTLIST_SYNC_D); break;
-            case PREF_VOLUME_BTN_SIZE: volumeBtnSize = p.getBoolean(key, PREF_VOLUME_BTN_SIZE_D); break;
+            case PREF_VOLUME_BTN_ROLE: setVolumeBtnRole(); break;
 
             // buffer list fragment
             case PREF_SHOW_BUFFER_FILTER: showBufferFilter = p.getBoolean(key, PREF_SHOW_BUFFER_FILTER_D); break;
@@ -237,6 +240,16 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
             case "left":      align = Color.ALIGN_LEFT; break;
             case "timestamp": align = Color.ALIGN_TIMESTAMP; break;
             default:          align = Color.ALIGN_NONE; break;
+        }
+    }
+
+    private static void setVolumeBtnRole() {
+        String role = p.getString(PREF_VOLUME_BTN_ROLE, PREF_VOLUME_BTN_ROLE_D);
+        switch (role) {
+            case "none":         volumeRole = VolumeRole.NONE; break;
+            case "text-size":    volumeRole = VolumeRole.TEXT_SIZE; break;
+            case "send-history": volumeRole = VolumeRole.SEND_HISTORY; break;
+            default:             volumeRole = VolumeRole.TEXT_SIZE; break;
         }
     }
 

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/utils/Constants.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/utils/Constants.java
@@ -62,7 +62,7 @@ public class Constants {
     // buttons
     public final static String PREF_SHOW_SEND = "sendbtn_show"; final public static boolean PREF_SHOW_SEND_D = true;
     public final static String PREF_SHOW_TAB = "tabbtn_show"; final public static boolean PREF_SHOW_TAB_D = true;
-    public final static String PREF_VOLUME_BTN_SIZE = "volumebtn_size"; final public static boolean PREF_VOLUME_BTN_SIZE_D = true;
+    public final static String PREF_VOLUME_BTN_ROLE = "volumebtn_role"; final public static String PREF_VOLUME_BTN_ROLE_D = "text-size";
 
     // notifications
     final static public String PREF_NOTIFICATION_ENABLE = "notification_enable"; final public static boolean PREF_NOTIFICATION_ENABLE_D = true;

--- a/weechat-android/src/main/res/values/strings.xml
+++ b/weechat-android/src/main/res/values/strings.xml
@@ -148,8 +148,12 @@
         <string name="pref_button_group">Buttons</string>
             <string name="pref_tabbtn_show">Show tab button</string>
             <string name="pref_sendbtn_show">Show send button</string>
-            <string name="pref_volumebtn_size">Volume buttons change text size</string>
-            <string name="pref_volumebtn_size_summary">If set, volume buttons will change text size instead of volume</string>
+            <string name="pref_volumebtn_role">Volume button role</string>
+                <string-array name="pref_volumebtn_role_names">
+                    <item>Do nothing</item>
+                    <item>Change text size</item>
+                    <item>Navigate send history</item>
+                </string-array>
 
         <!-- notifications -->
 

--- a/weechat-android/src/main/res/values/values.xml
+++ b/weechat-android/src/main/res/values/values.xml
@@ -14,6 +14,11 @@
         <item >websocket</item>
         <item >websocket-ssl</item>
     </string-array>
+    <string-array name="settings_volumebtn_role_values">
+        <item>none</item>
+        <item>text-size</item>
+        <item>send-history</item>
+    </string-array>
 
     <dimen name="dialog_item_padding_vertical">8dp</dimen>
     <dimen name="drawer_width">320dp</dimen>

--- a/weechat-android/src/main/res/xml/preferences.xml
+++ b/weechat-android/src/main/res/xml/preferences.xml
@@ -72,7 +72,7 @@
     <PreferenceScreen android:key="button_group" android:title="@string/pref_button_group">
 		<CheckBoxPreference android:key="tabbtn_show" android:title="@string/pref_tabbtn_show" android:defaultValue="true" />
 		<CheckBoxPreference android:key="sendbtn_show" android:title="@string/pref_sendbtn_show" android:defaultValue="true" />
-		<CheckBoxPreference android:key="volumebtn_size" android:title="@string/pref_volumebtn_size" android:summary="@string/pref_volumebtn_size_summary" android:defaultValue="true" />
+		<ListPreference android:key="volumebtn_role" android:title="@string/pref_volumebtn_role" android:summary="%s" android:defaultValue="text-size" android:entries="@array/pref_volumebtn_role_names" android:entryValues="@array/settings_volumebtn_role_values" />
 	</PreferenceScreen>
 
     <!-- notifications -->


### PR DESCRIPTION
Keeps the default setting to "text size" for backwards compatibility. This implements feature request #281.

Change summary:
- preferences: replaces _volume button for text-size_ checkbox with a dropdown with three choices: _do nothing_, _text size_, _navigate send history_
- change implementation in `BufferFragment` to account for the new setting

Note that when the user starts to type something in `uiInput` _then_ decides to navigate history, this draft is stored so they can come back to it by pressing _volume down_ all the way.

<img title="Button settings" src="https://i.imgur.com/zm07Xse.png" width="49%"/> <img title="Role selector" src="https://i.imgur.com/3swni8Z.png" width="49%"/>
