### PR TITLE
Separate system & user TrustStores; add cert count in clear cert pref

### DIFF
--- a/weechat-android/src/main/java/android/support/v7/preference/ClearCertPreference.java
+++ b/weechat-android/src/main/java/android/support/v7/preference/ClearCertPreference.java
@@ -12,7 +12,10 @@ import android.support.v7.app.AlertDialog;
 import android.util.AttributeSet;
 import android.widget.Toast;
 
+import com.ubergeek42.WeechatAndroid.R;
 import com.ubergeek42.WeechatAndroid.service.SSLHandler;
+
+import java.text.MessageFormat;
 
 public class ClearCertPreference extends DialogPreference {
 
@@ -20,6 +23,13 @@ public class ClearCertPreference extends DialogPreference {
 
     public ClearCertPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
+        update();
+    }
+
+    private void update() {
+        final int count = SSLHandler.getInstance(getContext()).getUserCertificateCount();
+        setEnabled(count > 0);
+        setSummary(MessageFormat.format(getContext().getString(R.string.pref_clear_certs_summary), count));
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -37,16 +47,22 @@ public class ClearCertPreference extends DialogPreference {
         protected void onPrepareDialogBuilder(AlertDialog.Builder builder) {
             super.onPrepareDialogBuilder(builder);
 
-            builder.setTitle(null).setMessage("Clear certificates?").
-                    setPositiveButton("Clear", new DialogInterface.OnClickListener() {
-                @Override public void onClick(DialogInterface dialog, int which) {
-                    boolean removed = SSLHandler.getInstance(getContext()).removeKeystore();
-                    String msg = removed ? "Keystore removed" : "Could not remove keystore";
-                    Toast.makeText(getContext(), msg, Toast.LENGTH_LONG).show();
-                }
-            }).setNegativeButton("Cancel", null);
+            builder.setTitle(null).setMessage(getString(R.string.pref_clear_certs_confirmation)).
+                    setPositiveButton(getString(R.string.pref_clear_certs_positive), new DialogInterface.OnClickListener() {
+                        @Override
+                        public void onClick(DialogInterface dialog, int which) {
+                            boolean removed = SSLHandler.getInstance(getContext()).removeKeystore();
+                            String msg = getString(removed ?
+                                    R.string.pref_clear_certs_success :
+                                    R.string.pref_clear_certs_failure);
+                            Toast.makeText(getContext(), msg, Toast.LENGTH_LONG).show();
+                        }
+                    }).setNegativeButton(getString(R.string.pref_clear_certs_negative), null);
         }
 
-        @Override public void onDialogClosed(boolean b) {}
+        @Override
+        public void onDialogClosed(boolean b) {
+            ((ClearCertPreference) getPreference()).update();
+        }
     }
 }

--- a/weechat-android/src/main/res/values/strings.xml
+++ b/weechat-android/src/main/res/values/strings.xml
@@ -64,6 +64,13 @@
                 <item>WebSocket (SSL)</item>
             </string-array>
 
+        <string name="pref_clear_certs_confirmation">Clear certificates?</string>
+        <string name="pref_clear_certs_summary">{0,choice,0#No trusted certificate|1#1 trusted certificate|1&lt;{0} trusted certificates}</string>
+        <string name="pref_clear_certs_positive">Clear</string>
+        <string name="pref_clear_certs_negative">Cancel</string>
+        <string name="pref_clear_certs_success">Certificates cleared</string>
+        <string name="pref_clear_certs_failure">Could not clear certificates</string>
+
         <string name="pref_stunnel_group">Stunnel settings</string>
             <string name="pref_stunnel_cert">Stunnel certificate file</string>
             <string name="pref_stunnel_pass">Stunnel password</string>


### PR DESCRIPTION
This fixes the [following TODO](/ubergeek42/weechat-android/blob/master/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/SSLHandler.java#L106):
```
// Copy current certs into our keystore so we can use it...
// TODO: don't actually do this...
```

Implementation summary:

- before: fill a single `Keystore` with all system certificates + all user certificates; check is done by `getTrustManagers()[0]`
- after: create a *system* `TrustManager` (with system `KeyStore`) and a *user* `TrustManager` (with user `KeyStore`); check is done by trying to check against the *system*, if that fails, the check is done against the *user*
- add a summary on the *Clear certificates* preference with the user certificate count
- put hard-coded strings to `strings.xml`

This way, we don't need to copy all ~150 system certificates. Besides, we can now clear only the user certificates.

<img title="Button settings" src="https://i.imgur.com/njaPGnh.png" width="49%"/> <img title="Role selector" src="https://i.imgur.com/wE4Z7Tl.png" width="49%"/>