### PR TITLE
Implement hostname verification for connection type ‘Weechat SSL’

### DIFF
--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
@@ -35,6 +35,7 @@ import java.util.LinkedList;
 import java.util.Locale;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 
 import static com.ubergeek42.WeechatAndroid.utils.Constants.*;
 
@@ -115,6 +116,7 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
     public static byte[] sshKey, sshKnownHosts;
     public static int port, sshPort;
     public static SSLContext sslContext;
+    public static SSLSocketFactory sslSocketFactory;
     public static boolean reconnect;
 
     public static boolean pingEnabled;
@@ -146,9 +148,11 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
         pingTimeout = Integer.parseInt(p.getString(PREF_PING_TIMEOUT, PREF_PING_TIMEOUT_D)) * 1000;
 
         if (Utils.isAnyOf(connectionType, PREF_TYPE_SSL, PREF_TYPE_WEBSOCKET_SSL)) {
+            sslSocketFactory = SSLHandler.getInstance(context).getSSLSocketFactory();
             sslContext = SSLHandler.getInstance(context).getSSLContext();
             if (sslContext == null) throw new RuntimeException("could not init sslContext");
         } else {
+            sslSocketFactory = null;
             sslContext = null;
         }
 

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/RelayService.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/RelayService.java
@@ -227,7 +227,7 @@ public class RelayService extends Service implements Connection.Observer {
         try {
             switch (P.connectionType) {
                 case PREF_TYPE_SSH: conn = new SSHConnection(P.host, P.port, P.sshHost, P.sshPort, P.sshUser, P.sshPass, P.sshKey, P.sshKnownHosts); break;
-                case PREF_TYPE_SSL: conn = new SSLConnection(P.host, P.port, P.sslContext); break;
+                case PREF_TYPE_SSL: conn = new SSLConnection(P.host, P.port, P.sslSocketFactory); break;
                 case PREF_TYPE_WEBSOCKET: conn = new WebSocketConnection(P.host, P.port, P.wsPath, null); break;
                 case PREF_TYPE_WEBSOCKET_SSL: conn = new WebSocketConnection(P.host, P.port, P.wsPath, P.sslContext); break;
                 default: conn = new PlainConnection(P.host, P.port); break;

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/SSLHandler.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/SSLHandler.java
@@ -6,6 +6,7 @@
 package com.ubergeek42.WeechatAndroid.service;
 
 import android.content.Context;
+import android.net.SSLCertificateSocketFactory;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -28,6 +29,7 @@ import java.security.cert.X509Certificate;
 import java.util.Arrays;
 
 import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.TrustManagerFactory;
 import javax.net.ssl.X509TrustManager;
@@ -84,6 +86,12 @@ public class SSLHandler {
             logger.error("getSSLContext()", e);
             return null;
         }
+    }
+
+    public SSLSocketFactory getSSLSocketFactory() {
+        SSLCertificateSocketFactory sslSocketFactory = (SSLCertificateSocketFactory) SSLCertificateSocketFactory.getDefault(0, null);
+        sslSocketFactory.setTrustManagers(UserTrustManager.build(sslKeystore));
+        return sslSocketFactory;
     }
 
     @CheckResult public boolean removeKeystore() {

--- a/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/SSLConnection.java
+++ b/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/SSLConnection.java
@@ -10,26 +10,26 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.channels.SocketChannel;
 
-import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 
 
 public class SSLConnection extends AbstractConnection {
 
     private String server;
     private int port;
-    SSLContext sslContext;
+    SSLSocketFactory sslSocketFactory;
     private Socket sock;
 
-    public SSLConnection(String server, int port, SSLContext sslContext) {
+    public SSLConnection(String server, int port, SSLSocketFactory sslSocketFactory) {
         this.server = server;
         this.port = port;
-        this.sslContext = sslContext;
+        this.sslSocketFactory = sslSocketFactory;
     }
 
     @Override protected void doConnect() throws IOException {
         SocketChannel channel = SocketChannel.open();
         channel.connect(new InetSocketAddress(server, port));
-        sock = sslContext.getSocketFactory().createSocket(channel.socket(), server, port, true);
+        sock = sslSocketFactory.createSocket(channel.socket(), server, port, true);
         out = sock.getOutputStream();
         in = sock.getInputStream();
     }


### PR DESCRIPTION
This partially fixes #266. Implementing for SSL WebSockets is not possible unless we use development release that gives access to `setSocket()`.

All the magic resides in the use of Android's `SSLCertificateSocketFactory` which implements hostname verification in its [`createSocket()`](https://developer.android.com/reference/android/net/SSLCertificateSocketFactory.html).