### PR TITLE
Use Java-WebSocket master to add hostname vertification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ addons:
   apt:
     packages:
       - python-openssl
+
 before_script:
-  - export PATH=$HOME/.local/bin:$PATH
-  - pip install --user `whoami` google-api-python-client
+  - 'export PATH="$HOME/.local/bin:$PATH"'
+  - pip install --user google-api-python-client
 # broken, see below with git depth 99999
 #  - git fetch --unshallow
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ subprojects {
         // Maven repo with viewpagerindicator: https://github.com/Goddchen/mvn-repo
         mavenCentral()
         mavenLocal()
+        maven { url "https://jitpack.io" }
     }
 }
 

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
@@ -115,7 +115,6 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
     public static String host, wsPath, pass, connectionType, sshHost, sshUser, sshPass;
     public static byte[] sshKey, sshKnownHosts;
     public static int port, sshPort;
-    public static SSLContext sslContext;
     public static SSLSocketFactory sslSocketFactory;
     public static boolean reconnect;
 
@@ -149,11 +148,8 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
 
         if (Utils.isAnyOf(connectionType, PREF_TYPE_SSL, PREF_TYPE_WEBSOCKET_SSL)) {
             sslSocketFactory = SSLHandler.getInstance(context).getSSLSocketFactory();
-            sslContext = SSLHandler.getInstance(context).getSSLContext();
-            if (sslContext == null) throw new RuntimeException("could not init sslContext");
         } else {
             sslSocketFactory = null;
-            sslContext = null;
         }
 
         printableHost = connectionType.equals(PREF_TYPE_SSH) ? sshHost + "/" + host : host;

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/RelayService.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/RelayService.java
@@ -229,7 +229,7 @@ public class RelayService extends Service implements Connection.Observer {
                 case PREF_TYPE_SSH: conn = new SSHConnection(P.host, P.port, P.sshHost, P.sshPort, P.sshUser, P.sshPass, P.sshKey, P.sshKnownHosts); break;
                 case PREF_TYPE_SSL: conn = new SSLConnection(P.host, P.port, P.sslSocketFactory); break;
                 case PREF_TYPE_WEBSOCKET: conn = new WebSocketConnection(P.host, P.port, P.wsPath, null); break;
-                case PREF_TYPE_WEBSOCKET_SSL: conn = new WebSocketConnection(P.host, P.port, P.wsPath, P.sslContext); break;
+                case PREF_TYPE_WEBSOCKET_SSL: conn = new WebSocketConnection(P.host, P.port, P.wsPath, P.sslSocketFactory); break;
                 default: conn = new PlainConnection(P.host, P.port); break;
             }
         } catch (Exception e) {

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/SSLHandler.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/SSLHandler.java
@@ -77,17 +77,6 @@ public class SSLHandler {
         saveKeystore();
     }
 
-    public @Nullable SSLContext getSSLContext() {
-        try {
-            SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, UserTrustManager.build(sslKeystore), new SecureRandom());
-            return sslContext;
-        } catch (NoSuchAlgorithmException | KeyManagementException e) {
-            logger.error("getSSLContext()", e);
-            return null;
-        }
-    }
-
     public SSLSocketFactory getSSLSocketFactory() {
         SSLCertificateSocketFactory sslSocketFactory = (SSLCertificateSocketFactory) SSLCertificateSocketFactory.getDefault(0, null);
         sslSocketFactory.setTrustManagers(UserTrustManager.build(sslKeystore));

--- a/weechat-relay/build.gradle
+++ b/weechat-relay/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 
 dependencies {
     compile 'org.slf4j:slf4j-api:1.7.12'
-    compile 'com.jcraft:jsch:0.1.53'                  // for ssh tunnel support
-    compile 'org.java-websocket:Java-WebSocket:1.3.0' // For websocket support
+    compile 'com.jcraft:jsch:0.1.53'                        // for ssh tunnel support
+    compile 'com.github.TooTallNate:Java-WebSocket:58d1778' // for websocket support
     compile 'junit:junit:4.12'
 }
 
@@ -14,4 +14,3 @@ compileJava {
 tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
-

--- a/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/WebSocketConnection.java
+++ b/weechat-relay/src/main/java/com/ubergeek42/weechat/relay/connection/WebSocketConnection.java
@@ -5,7 +5,6 @@
 
 package com.ubergeek42.weechat.relay.connection;
 
-import org.java_websocket.client.DefaultSSLWebSocketClientFactory;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.drafts.Draft;
 import org.java_websocket.drafts.Draft_17;
@@ -21,7 +20,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
 
-import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
 
 public class WebSocketConnection extends AbstractConnection {
     protected static Logger logger = LoggerFactory.getLogger("WebSocketConnection");
@@ -29,9 +28,9 @@ public class WebSocketConnection extends AbstractConnection {
     private WebSocketClient client;
     private PipedOutputStream outputToInStream;
 
-    public WebSocketConnection(String server, int port, String path, SSLContext sslContext) throws URISyntaxException, IOException {
+    public WebSocketConnection(String server, int port, String path, SSLSocketFactory sslSocketFactory) throws URISyntaxException, IOException {
         // can throw URISyntaxException
-        URI uri = new URI(sslContext == null ? "ws" : "wss", null, server, port, "/" + path, null, null);
+        URI uri = new URI(sslSocketFactory == null ? "ws" : "wss", null, server, port, "/" + path, null, null);
 
         // can throw IOException
         in = new PipedInputStream();
@@ -39,7 +38,8 @@ public class WebSocketConnection extends AbstractConnection {
         outputToInStream.connect((PipedInputStream) in);
 
         client = new MyWebSocket(uri, new Draft_17());
-        if (sslContext != null) client.setWebSocketFactory(new DefaultSSLWebSocketClientFactory(sslContext));
+        if (sslSocketFactory != null)
+            client.setSocket(sslSocketFactory.createSocket(server, port));
     }
 
     @Override protected void doConnect() throws Exception {


### PR DESCRIPTION
Follow-up for #266.

- use *jitpack.io* to add dependency to Java-WebSocket [current HEAD](/TooTallNate/Java-WebSocket/commit/58d17786958ec2b629b75de1eed00915b3e4f7c4)
- remove `sslContext`! yay!
- use `sslSocketFactory` to build the websocket socket, now that we can use `setSocket()`
