### PR TITLE
Allow the user to configure the auto-capitalization and auto-correction for chat messages.

### DIFF
--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.java
@@ -140,7 +140,7 @@ public class BufferFragment extends Fragment implements BufferEye, OnKeyListener
         started = true;
         uiSend.setVisibility(P.showSend ? View.VISIBLE : View.GONE);
         uiTab.setVisibility(P.showTab ? View.VISIBLE : View.GONE);
-        int inputType = InputType.TYPE_CLASS_TEXT;
+        int inputType = InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
 
         if(P.enableAutoCorrect) {
             inputType |= InputType.TYPE_TEXT_FLAG_AUTO_CORRECT;

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import android.content.Context;
 import android.os.Bundle;
 import android.text.Editable;
+import android.text.InputType;
 import android.text.TextWatcher;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -35,6 +36,7 @@ import com.ubergeek42.WeechatAndroid.relay.BufferEye;
 import com.ubergeek42.WeechatAndroid.relay.BufferList;
 import com.ubergeek42.WeechatAndroid.relay.Line;
 import com.ubergeek42.WeechatAndroid.service.P;
+import com.ubergeek42.WeechatAndroid.utils.ActionEditText;
 import com.ubergeek42.WeechatAndroid.utils.CopyPaste;
 import com.ubergeek42.weechat.ColorScheme;
 
@@ -138,6 +140,17 @@ public class BufferFragment extends Fragment implements BufferEye, OnKeyListener
         started = true;
         uiSend.setVisibility(P.showSend ? View.VISIBLE : View.GONE);
         uiTab.setVisibility(P.showTab ? View.VISIBLE : View.GONE);
+        int inputType = InputType.TYPE_CLASS_TEXT;
+
+        if(P.enableAutoCorrect) {
+            inputType |= InputType.TYPE_TEXT_FLAG_AUTO_CORRECT;
+        } else {
+            inputType |= InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS;
+        }
+        if(P.enableAutoCapitalize) {
+            inputType |= InputType.TYPE_TEXT_FLAG_CAP_SENTENCES;
+        }
+        uiInput.setInputType(inputType);
         uiLines.setBackgroundColor(0xFF000000 | ColorScheme.get().defaul[ColorScheme.OPT_BG]);
         EventBus.getDefault().registerSticky(this);
     }

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.java
@@ -1,15 +1,10 @@
 package com.ubergeek42.WeechatAndroid.fragments;
 
-import java.util.Vector;
-
 import android.annotation.SuppressLint;
-import android.support.annotation.NonNull;
-import android.support.v4.app.Fragment;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import android.content.Context;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.Fragment;
 import android.text.Editable;
 import android.text.InputType;
 import android.text.TextWatcher;
@@ -27,23 +22,28 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.ubergeek42.WeechatAndroid.adapters.ChatLinesAdapter;
 import com.ubergeek42.WeechatAndroid.R;
 import com.ubergeek42.WeechatAndroid.WeechatActivity;
+import com.ubergeek42.WeechatAndroid.adapters.ChatLinesAdapter;
 import com.ubergeek42.WeechatAndroid.relay.Buffer;
 import com.ubergeek42.WeechatAndroid.relay.Buffer.LINES;
 import com.ubergeek42.WeechatAndroid.relay.BufferEye;
 import com.ubergeek42.WeechatAndroid.relay.BufferList;
 import com.ubergeek42.WeechatAndroid.relay.Line;
 import com.ubergeek42.WeechatAndroid.service.P;
-import com.ubergeek42.WeechatAndroid.utils.ActionEditText;
 import com.ubergeek42.WeechatAndroid.utils.CopyPaste;
 import com.ubergeek42.weechat.ColorScheme;
 
-import static com.ubergeek42.WeechatAndroid.service.Events.*;
-import static com.ubergeek42.WeechatAndroid.service.RelayService.STATE.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Vector;
 
 import de.greenrobot.event.EventBus;
+
+import static com.ubergeek42.WeechatAndroid.service.Events.SendMessageEvent;
+import static com.ubergeek42.WeechatAndroid.service.Events.StateChangedEvent;
+import static com.ubergeek42.WeechatAndroid.service.RelayService.STATE.LISTED;
 
 public class BufferFragment extends Fragment implements BufferEye, OnKeyListener,
         OnClickListener, TextWatcher, TextView.OnEditorActionListener {

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
@@ -71,7 +71,8 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
     public static boolean notificationEnable, notificationTicker, notificationLight, notificationVibrate;
     public static String notificationSound;
 
-    public static boolean showSend, showTab, hotlistSync, volumeBtnSize;
+    public static boolean showSend, showTab, enableAutoCapitalize, enableAutoCorrect, hotlistSync;
+    public static boolean volumeBtnSize;
     public static String bufferFont;
 
     public static boolean showBufferFilter;
@@ -104,6 +105,8 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
         // buffer fragment
         showSend = p.getBoolean(PREF_SHOW_SEND, PREF_SHOW_SEND_D);
         showTab = p.getBoolean(PREF_SHOW_TAB, PREF_SHOW_TAB_D);
+        enableAutoCapitalize = p.getBoolean(PREF_ENABLE_AUTO_CAPITALIZE, PREF_ENABLE_AUTO_CAPITALIZE_D);
+        enableAutoCorrect = p.getBoolean(PREF_ENABLE_AUTO_CORRECT, PREF_ENABLE_AUTO_CORRECT_D);
         hotlistSync = p.getBoolean(PREF_HOTLIST_SYNC, PREF_HOTLIST_SYNC_D);
         volumeBtnSize = p.getBoolean(PREF_VOLUME_BTN_SIZE, PREF_VOLUME_BTN_SIZE_D);
 
@@ -223,6 +226,8 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
             // buffer fragment
             case PREF_SHOW_SEND: showSend = p.getBoolean(key, PREF_SHOW_SEND_D); break;
             case PREF_SHOW_TAB: showTab = p.getBoolean(key, PREF_SHOW_TAB_D); break;
+            case PREF_ENABLE_AUTO_CAPITALIZE: enableAutoCapitalize = p.getBoolean(key, PREF_ENABLE_AUTO_CAPITALIZE_D); break;
+            case PREF_ENABLE_AUTO_CORRECT: enableAutoCorrect = p.getBoolean(key, PREF_ENABLE_AUTO_CORRECT_D); break;
             case PREF_HOTLIST_SYNC: hotlistSync = p.getBoolean(key, PREF_HOTLIST_SYNC_D); break;
             case PREF_VOLUME_BTN_SIZE: volumeBtnSize = p.getBoolean(key, PREF_VOLUME_BTN_SIZE_D); break;
 

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/utils/ActionEditText.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/utils/ActionEditText.java
@@ -2,6 +2,7 @@ package com.ubergeek42.WeechatAndroid.utils;
 
 import android.content.Context;
 import android.support.v7.widget.AppCompatEditText;
+import android.text.InputType;
 import android.util.AttributeSet;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
@@ -23,6 +24,7 @@ public class ActionEditText extends AppCompatEditText {
     public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
         InputConnection conn = super.onCreateInputConnection(outAttrs);
         outAttrs.imeOptions &= ~EditorInfo.IME_FLAG_NO_ENTER_ACTION;
+        outAttrs.inputType &= ~InputType.TYPE_TEXT_FLAG_MULTI_LINE;
         return conn;
     }
 }

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/utils/Constants.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/utils/Constants.java
@@ -66,6 +66,8 @@ public class Constants {
     // buttons
     public final static String PREF_SHOW_SEND = "sendbtn_show"; final public static boolean PREF_SHOW_SEND_D = true;
     public final static String PREF_SHOW_TAB = "tabbtn_show"; final public static boolean PREF_SHOW_TAB_D = true;
+    public final static String PREF_ENABLE_AUTO_CORRECT = "autocorrect_input"; final public static boolean PREF_ENABLE_AUTO_CORRECT_D = true;
+    public final static String PREF_ENABLE_AUTO_CAPITALIZE = "autocapitalize_input"; final public static boolean PREF_ENABLE_AUTO_CAPITALIZE_D = true;
     public final static String PREF_VOLUME_BTN_SIZE = "volumebtn_size"; final public static boolean PREF_VOLUME_BTN_SIZE_D = true;
 
     // notifications

--- a/weechat-android/src/main/res/layout/chatview_main.xml
+++ b/weechat-android/src/main/res/layout/chatview_main.xml
@@ -19,7 +19,7 @@
             android:layout_weight="1.0"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:inputType="textCapSentences|textMultiLine|textAutoCorrect"
+            android:inputType="textMultiLine"
             android:imeOptions="flagNoFullscreen|flagNoExtractUi|actionSend"
             android:maxLines="4"
             android:minLines="1"

--- a/weechat-android/src/main/res/layout/chatview_main.xml
+++ b/weechat-android/src/main/res/layout/chatview_main.xml
@@ -19,7 +19,6 @@
             android:layout_weight="1.0"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:inputType="textMultiLine"
             android:imeOptions="flagNoFullscreen|flagNoExtractUi|actionSend"
             android:maxLines="4"
             android:minLines="1"

--- a/weechat-android/src/main/res/values/strings.xml
+++ b/weechat-android/src/main/res/values/strings.xml
@@ -234,9 +234,11 @@
 
         <!-- buttons -->
 
-        <string name="pref_button_group">Buttons</string>
+        <string name="pref_button_group">Buttons &amp; input</string>
             <string name="pref_tabbtn_show">Show tab button</string>
             <string name="pref_sendbtn_show">Show send button</string>
+            <string name="pref_autocapitalize_enable">Enable keyboard auto-capitalization</string>
+            <string name="pref_autocorrect_enable">Enable keyboard auto-correct</string>
             <string name="pref_volumebtn_size">Volume buttons change text size</string>
             <string name="pref_volumebtn_size_summary">If set, volume buttons will change text size instead of volume</string>
 

--- a/weechat-android/src/main/res/values/strings.xml
+++ b/weechat-android/src/main/res/values/strings.xml
@@ -238,7 +238,6 @@
             <string name="pref_tabbtn_show">Show tab button</string>
             <string name="pref_sendbtn_show">Show send button</string>
             <string name="pref_autocapitalize_enable">Enable keyboard auto-capitalization</string>
-            <string name="pref_autocapitalize_enable_summary">Some keyboards (such as SwiftKey) will refuse to disable auto-capitalization.</string>
             <string name="pref_autocorrect_enable">Enable keyboard auto-correct</string>
             <string name="pref_volumebtn_size">Volume buttons change text size</string>
             <string name="pref_volumebtn_size_summary">If set, volume buttons will change text size instead of volume</string>

--- a/weechat-android/src/main/res/values/strings.xml
+++ b/weechat-android/src/main/res/values/strings.xml
@@ -238,6 +238,7 @@
             <string name="pref_tabbtn_show">Show tab button</string>
             <string name="pref_sendbtn_show">Show send button</string>
             <string name="pref_autocapitalize_enable">Enable keyboard auto-capitalization</string>
+            <string name="pref_autocapitalize_enable_summary">Some keyboards (such as SwiftKey) will refuse to disable auto-capitalization.</string>
             <string name="pref_autocorrect_enable">Enable keyboard auto-correct</string>
             <string name="pref_volumebtn_size">Volume buttons change text size</string>
             <string name="pref_volumebtn_size_summary">If set, volume buttons will change text size instead of volume</string>

--- a/weechat-android/src/main/res/xml/preferences.xml
+++ b/weechat-android/src/main/res/xml/preferences.xml
@@ -75,7 +75,7 @@
 		<CheckBoxPreference android:key="tabbtn_show" android:title="@string/pref_tabbtn_show" android:defaultValue="true" />
 		<CheckBoxPreference android:key="sendbtn_show" android:title="@string/pref_sendbtn_show" android:defaultValue="true" />
         <CheckBoxPreference android:key="autocorrect_input" android:title="@string/pref_autocorrect_enable" android:defaultValue="true" />
-        <CheckBoxPreference android:key="autocapitalize_input" android:title="@string/pref_autocapitalize_enable" android:defaultValue="true" />
+        <CheckBoxPreference android:key="autocapitalize_input" android:title="@string/pref_autocapitalize_enable" android:defaultValue="true" android:summary="@string/pref_autocapitalize_enable_summary" />
         <CheckBoxPreference android:key="volumebtn_size" android:title="@string/pref_volumebtn_size" android:summary="@string/pref_volumebtn_size_summary" android:defaultValue="true" />
 	</PreferenceScreen>
 

--- a/weechat-android/src/main/res/xml/preferences.xml
+++ b/weechat-android/src/main/res/xml/preferences.xml
@@ -75,7 +75,7 @@
 		<CheckBoxPreference android:key="tabbtn_show" android:title="@string/pref_tabbtn_show" android:defaultValue="true" />
 		<CheckBoxPreference android:key="sendbtn_show" android:title="@string/pref_sendbtn_show" android:defaultValue="true" />
         <CheckBoxPreference android:key="autocorrect_input" android:title="@string/pref_autocorrect_enable" android:defaultValue="true" />
-        <CheckBoxPreference android:key="autocapitalize_input" android:title="@string/pref_autocapitalize_enable" android:defaultValue="true" android:summary="@string/pref_autocapitalize_enable_summary" />
+        <CheckBoxPreference android:key="autocapitalize_input" android:title="@string/pref_autocapitalize_enable" android:defaultValue="true" />
         <CheckBoxPreference android:key="volumebtn_size" android:title="@string/pref_volumebtn_size" android:summary="@string/pref_volumebtn_size_summary" android:defaultValue="true" />
 	</PreferenceScreen>
 

--- a/weechat-android/src/main/res/xml/preferences.xml
+++ b/weechat-android/src/main/res/xml/preferences.xml
@@ -74,7 +74,9 @@
     <PreferenceScreen android:key="button_group" android:title="@string/pref_button_group">
 		<CheckBoxPreference android:key="tabbtn_show" android:title="@string/pref_tabbtn_show" android:defaultValue="true" />
 		<CheckBoxPreference android:key="sendbtn_show" android:title="@string/pref_sendbtn_show" android:defaultValue="true" />
-		<CheckBoxPreference android:key="volumebtn_size" android:title="@string/pref_volumebtn_size" android:summary="@string/pref_volumebtn_size_summary" android:defaultValue="true" />
+        <CheckBoxPreference android:key="autocorrect_input" android:title="@string/pref_autocorrect_enable" android:defaultValue="true" />
+        <CheckBoxPreference android:key="autocapitalize_input" android:title="@string/pref_autocapitalize_enable" android:defaultValue="true" />
+        <CheckBoxPreference android:key="volumebtn_size" android:title="@string/pref_volumebtn_size" android:summary="@string/pref_volumebtn_size_summary" android:defaultValue="true" />
 	</PreferenceScreen>
 
     <!-- notifications -->

--- a/weechat-android/src/main/res/xml/preferences.xml
+++ b/weechat-android/src/main/res/xml/preferences.xml
@@ -74,9 +74,9 @@
     <PreferenceScreen android:key="button_group" android:title="@string/pref_button_group">
 		<CheckBoxPreference android:key="tabbtn_show" android:title="@string/pref_tabbtn_show" android:defaultValue="true" />
 		<CheckBoxPreference android:key="sendbtn_show" android:title="@string/pref_sendbtn_show" android:defaultValue="true" />
-        <CheckBoxPreference android:key="autocorrect_input" android:title="@string/pref_autocorrect_enable" android:defaultValue="true" />
-        <CheckBoxPreference android:key="autocapitalize_input" android:title="@string/pref_autocapitalize_enable" android:defaultValue="true" />
-        <CheckBoxPreference android:key="volumebtn_size" android:title="@string/pref_volumebtn_size" android:summary="@string/pref_volumebtn_size_summary" android:defaultValue="true" />
+		<CheckBoxPreference android:key="autocorrect_input" android:title="@string/pref_autocorrect_enable" android:defaultValue="true" />
+		<CheckBoxPreference android:key="autocapitalize_input" android:title="@string/pref_autocapitalize_enable" android:defaultValue="true" />
+		<CheckBoxPreference android:key="volumebtn_size" android:title="@string/pref_volumebtn_size" android:summary="@string/pref_volumebtn_size_summary" android:defaultValue="true" />
 	</PreferenceScreen>
 
     <!-- notifications -->


### PR DESCRIPTION
Adds two preferences to allow the user to disable auto-correction and auto-capitalization on the chat message input EditText. To work around a SwiftKey bug/feature we set multi line mode (InputType.TYPE_TEXT_FLAG_MULTI_LINE) on the ActionEditText but don't actually send it on to the IME itself.