### PR TITLE
Fingerprint policy for certificates

### DIFF
--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/utils/UntrustedCertificateDialog.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/utils/UntrustedCertificateDialog.java
@@ -73,7 +73,7 @@ public class UntrustedCertificateDialog extends DialogFragment {
 
     public String getCertificateDescription() {
         String fingerprint;
-        try {fingerprint = new String(Hex.encodeHex(DigestUtils.sha1(certificate.getEncoded())));}
+        try {fingerprint = new String(Hex.encodeHex(DigestUtils.sha256(certificate.getEncoded())));}
         catch (CertificateEncodingException e) {fingerprint = getString(R.string.ssl_cert_dialog_unknown_fingerprint); }
         return getString(R.string.ssl_cert_dialog_description,
                 certificate.getSubjectDN().getName(),

--- a/weechat-android/src/main/res/values-fr/strings.xml
+++ b/weechat-android/src/main/res/values-fr/strings.xml
@@ -155,7 +155,7 @@
         Émis le : %3$s<br>
         Expire le : %4$s<br>
         <br>
-        <b>Empreinte SHA-1 :</b><br>
+        <b>Empreinte SHA-256 :</b><br>
         %5$s
     ]]></string>
     <string name="pref_file_choose_button">Choisir un fichier</string>

--- a/weechat-android/src/main/res/values/strings.xml
+++ b/weechat-android/src/main/res/values/strings.xml
@@ -81,7 +81,7 @@
         Issued On: %3$s<br>
         Expires On: %4$s<br>
         <br>
-        <b>SHA-1 Fingerprint:</b><br>
+        <b>SHA-256 Fingerprint:</b><br>
         %5$s
     ]]></string>
     <string name="ssl_cert_dialog_title">Untrusted certificate</string>


### PR DESCRIPTION
https://www.quora.com/Cryptography-Why-are-MD5-and-SHA1-called-broken-algorithms

One should now transition to sha-2 algorithms.

https://commons.apache.org/proper/commons-codec/apidocs/org/apache/commons/codec/digest/DigestUtils.html#sha256%28java.lang.String%29

(note that DigestUtils.sha256Hex could be used instead of converting to Hex afterwards -?-)