### PR TITLE
Use buffer names instead of pointers to avoid WeeChat crash

### DIFF
--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/WeechatActivity.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/WeechatActivity.java
@@ -448,7 +448,7 @@ public class WeechatActivity extends AppCompatActivity implements
                     @Override
                     public void onClick(DialogInterface dialogInterface, int position) {
                         Nick nick = nicklistAdapter.getItem(position);
-                        EventBus.getDefault().post(new SendMessageEvent(String.format("input %s /query %s", buffer.hexPointer(), nick.name)));
+                        EventBus.getDefault().post(new SendMessageEvent(String.format("input %s /query %s", buffer.fullName, nick.name)));
                     }
                 });
                 AlertDialog dialog = builder.create();

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.java
@@ -212,8 +212,8 @@ public class BufferFragment extends Fragment implements BufferEye, OnKeyListener
 
         // move the read marker in weechat (if preferences dictate)
         if (!watched && P.hotlistSync) {
-            EventBus.getDefault().post(new SendMessageEvent(String.format("input %s /buffer set hotlist -1", buffer.hexPointer())));
-            EventBus.getDefault().post(new SendMessageEvent(String.format("input %s /input set_unread_current_buffer", buffer.hexPointer())));
+            EventBus.getDefault().post(new SendMessageEvent(String.format("input %s /buffer set hotlist -1", buffer.fullName)));
+            EventBus.getDefault().post(new SendMessageEvent(String.format("input %s /input set_unread_current_buffer", buffer.fullName)));
         }
     }
 
@@ -489,7 +489,7 @@ public class BufferFragment extends Fragment implements BufferEye, OnKeyListener
         String[] lines = input.split("\n");
         for (String line : lines) {
             if (line.length() != 0)
-                EventBus.getDefault().post(new SendMessageEvent(String.format("input %s %s", buffer.hexPointer(), line)));
+                EventBus.getDefault().post(new SendMessageEvent(String.format("input %s %s", buffer.fullName, line)));
         }
         uiInput.setText("");   // this will reset tab completion
     }

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/relay/BufferList.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/relay/BufferList.java
@@ -228,11 +228,11 @@ public class BufferList {
     /** send sync command to relay (if traffic is set to optimized) and
      ** add it to the synced buffers (=open buffers) list */
     synchronized static void syncBuffer(Buffer buffer) {
-        if (P.optimizeTraffic) sendMessage(String.format("sync %s", buffer.hexPointer()));
+        if (P.optimizeTraffic) sendMessage(String.format("sync %s", buffer.fullName));
     }
 
     synchronized static void desyncBuffer(Buffer buffer) {
-        if (P.optimizeTraffic) sendMessage(String.format("desync %s", buffer.hexPointer()));
+        if (P.optimizeTraffic) sendMessage(String.format("desync %s", buffer.fullName));
     }
 
     private static int counter = 0;


### PR DESCRIPTION
I've had WeeChat crashing frequently due to weechat-android sending an invalid pointer in the `desync` relay command. According to @FlashCode, buffer names should be used instead of pointers whenever possible - that way it won't crash if an invalid buffer is given. I've tested this and everything still works correctly.

Closes #345.