### PR TITLE
Prevent Buffer Filtering in the Sharing Intent

### DIFF
--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/ShareTextActivity.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/ShareTextActivity.java
@@ -31,7 +31,7 @@ public class ShareTextActivity extends AppCompatActivity implements DialogInterf
 
         Intent intent = getIntent();
         if ((Intent.ACTION_SEND.equals(intent.getAction()) && "text/plain".equals(intent.getType()))) {
-            bufferlistAdapter = new BufferListAdapter(this);
+            bufferlistAdapter = new BufferListAdapter(this).preventFilter();
             AlertDialog.Builder builder = new AlertDialog.Builder(this)
                     .setAdapter(bufferlistAdapter, this)
                     .setTitle(getString(R.string.share_text_title));

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/adapters/BufferListAdapter.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/adapters/BufferListAdapter.java
@@ -138,6 +138,11 @@ public class BufferListAdapter extends BaseAdapter implements BufferListEye {
         });
     }
 
+    public BufferListAdapter preventFilter() {
+        BufferList.setFilter("");
+        return this;
+    }
+
     @Override
     public void onHotCountChanged() {}
 }


### PR DESCRIPTION
Signed-off-by: Martin Weinelt <hexa@darmstadt.ccc.de>

I'm a a java derp, I tested this in the VM and it worked. Not sure if this is the proper way.

This change prevents buffer filtering to affect the available buffers in the sharing intent.

The filter is only reset in the sharing intent, it is not reset inside the app.