### PR TITLE
[WIP] Notifications: added reply butotn to instant reply to highlights/queries

### DIFF
--- a/weechat-android/src/main/AndroidManifest.xml
+++ b/weechat-android/src/main/AndroidManifest.xml
@@ -57,5 +57,6 @@
             </intent-filter>
         </receiver>
         <receiver android:name=".service.SyncAlarmReceiver" />
+        <receiver android:name=".service.ReplyReceiver" />
     </application>
 </manifest>

--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/ReplyReceiver.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/ReplyReceiver.java
@@ -1,0 +1,93 @@
+package com.ubergeek42.WeechatAndroid.service;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.Service;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.IBinder;
+import android.support.annotation.Nullable;
+import android.support.v4.app.RemoteInput;
+
+import com.ubergeek42.WeechatAndroid.R;
+import com.ubergeek42.WeechatAndroid.WeechatActivity;
+import com.ubergeek42.WeechatAndroid.relay.Buffer;
+import com.ubergeek42.WeechatAndroid.relay.BufferList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import de.greenrobot.event.EventBus;
+
+/**
+ * Created by andi on 4/11/17.
+ */
+
+public class ReplyReceiver extends BroadcastReceiver {
+    private static Logger logger = LoggerFactory.getLogger("ReplyReceiver");
+
+    final public static String ACTION_REPLY = "ACTION_REPLY";
+
+    public ReplyReceiver() {
+        super();
+
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent)  {
+        logger.error("onStartCommand");
+        if (intent != null) {
+            final String action = intent.getAction();
+            logger.error(action);
+            if (ACTION_REPLY.equals(action)) {
+                doReply(context, intent);
+            }
+        }
+    }
+
+    private void doReply(Context context, Intent intent) {
+        // Get remote input from received intent. Remote input is an answer a user has added to the reply. In our case it should contain a String.
+        Bundle remoteInput = RemoteInput.getResultsFromIntent(intent);
+        if (remoteInput == null) {
+            logger.debug("remoteInput is null");
+            return;
+        }
+
+        // Get channel
+
+        final String bufferName = intent.getStringExtra("full_name");
+
+
+        // Get reply text
+        String text = remoteInput.getString(Notificator.KEY_TEXT_REPLY);
+        logger.error(text);
+
+        Buffer buffer = BufferList.findByFullName(bufferName);
+
+        if (buffer == null) {
+            logger.error("Unknown buffer");
+            return;
+        }
+
+
+        P.addSentMessage(text);
+        String[] lines = text.split("\n");
+        for (String line : lines) {
+            if (line.length() != 0)
+                EventBus.getDefault().post(new Events.SendMessageEvent(String.format("input %s %s", buffer.hexPointer(), line)));
+        }
+
+
+        Notification repliedNotification =
+                new Notification.Builder(context)
+                        .setSmallIcon(R.drawable.ic_send)
+                        .setContentText("Replied")
+                        .build();
+
+        // Issue the new notification.
+        Notificator.notify(Notificator.NOTIFICATION_HOT_ID, repliedNotification);
+
+    }
+}

--- a/weechat-android/src/main/res/values/strings.xml
+++ b/weechat-android/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="notification_upgrading_details">WeeChat is upgrading, please wait for reconnection</string>
     <string name="notification_waiting_network">Waiting for network</string>
     <string name="notification_waiting_network_details">Failed to connect, network unavailable</string>
+    <string name="notification_reply_text">Reply</string>
 
     <!-- toasts -->
     <string name="autoscroll_no_line">Buffer lost some hot messages because of new lines</string>


### PR DESCRIPTION
I spent a few hours tinkering with adding a reply feature to the notifications as known from most of the major messengers.
The code quality of this PR is rather week IMO. I just post it here to save someone else time if I drop this idea...

I'm not very happy with the code and it feels like we should rework the entire notification architecture.
I was thinking about two modes:
1) the current state (one notification per buffer)
2) one notification per buffer

Any thoughts?
