### PR TITLE
Fix NPE on using invalid uiLines

### DIFF
--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.java
@@ -146,7 +146,8 @@ public class BufferFragment extends Fragment implements BufferEye, OnKeyListener
     @Override
     public void onSaveInstanceState(Bundle outState) {
         // Backup top visible item for later restore
-        visiblePosition = uiLines.getFirstVisiblePosition();
+        if (uiLines != null)
+            visiblePosition = uiLines.getFirstVisiblePosition();
         super.onSaveInstanceState(outState);
     }
 


### PR DESCRIPTION
Crash stacktrace:
> 08-14 13:15:00.572  4023  4023 D AndroidRuntime: Shutting down VM
08-14 13:15:00.579  4023  4023 E AndroidRuntime: FATAL EXCEPTION: main
08-14 13:15:00.579  4023  4023 E AndroidRuntime: Process: com.ubergeek42.WeechatAndroid.dev, PID: 4023
08-14 13:15:00.579  4023  4023 E AndroidRuntime: java.lang.NullPointerException: Attempt to invoke virtual method 'int android.widget.AdapterView.getFirstVisiblePosition()' on a null object reference
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at com.ubergeek42.WeechatAndroid.fragments.BufferFragment.onSaveInstanceState(BufferFragment.java:149)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at android.support.v4.app.Fragment.performSaveInstanceState(Fragment.java:2112)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at android.support.v4.app.FragmentManagerImpl.saveAllState(FragmentManager.java:10778)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at android.support.v4.app.FragmentActivity.onSaveInstanceState(FragmentActivity.java:16125)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at android.app.Activity.performSaveInstanceState(Activity.java:1415)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at android.app.Instrumentation.callActivityOnSaveInstanceState(Instrumentation.java:1301)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at android.app.ActivityThread.callCallActivityOnSaveInstanceState(ActivityThread.java:4593)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at android.app.ActivityThread.performStopActivityInner(ActivityThread.java:3908)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at android.app.ActivityThread.handleStopActivity(ActivityThread.java:3967)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at android.app.ActivityThread.-wrap25(ActivityThread.java)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1541)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:102)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:154)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at android.app.ActivityThread.main(ActivityThread.java:6236)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at java.lang.reflect.Method.invoke(Native Method)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:891)
08-14 13:15:00.579  4023  4023 E AndroidRuntime: 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:781)
08-14 13:15:00.584  1128  1228 W ActivityManager:   Force finishing activity com.ubergeek42.WeechatAndroid.dev/com.ubergeek42.WeechatAndroid.WeechatActivity