### PR TITLE
Fix crash when ping is disabled

### DIFF
--- a/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/PingActionReceiver.java
+++ b/weechat-android/src/main/java/com/ubergeek42/WeechatAndroid/service/PingActionReceiver.java
@@ -88,7 +88,11 @@ public class PingActionReceiver extends BroadcastReceiver {
         Intent intent = new Intent(PING_ACTION);
         PendingIntent alarmIntent = PendingIntent.getBroadcast(bone, 0, intent, PendingIntent.FLAG_NO_CREATE);
         alarmManager.cancel(alarmIntent);
-        bone.unregisterReceiver(this);
+        try {
+            bone.unregisterReceiver(this);
+        } catch (IllegalArgumentException ignored) {
+            // Ping is not enabled or was not enabled during initialization
+        }
     }
 
     public void onMessage() {


### PR DESCRIPTION
Fixes #347. Since changing the setting in the menu does not immediately start the `PingActionReceiver`, checking `P.pingEnabled` is not enough and just catching the exception is the cleaner way.