### PR TITLE
fix socket closed before getting certificate

### DIFF
--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/service/SSLHandler.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/service/SSLHandler.java
@@ -79,8 +79,9 @@ public class SSLHandler {
         }
         SSLSession session = ssl.getSession();
         boolean verified = HttpsURLConnection.getDefaultHostnameVerifier().verify(host, session);
+        X509Certificate certificate = getCertificate(ssl);
         try {ssl.close();} catch (IOException ignored) {}
-        return new Result(verified, getCertificate(ssl));
+        return new Result(verified, certificate);
     }
 
     private static @Nullable X509Certificate getCertificate(SSLSocket socket) {


### PR DESCRIPTION
i'm not sure how this worked in the first place, but it definitely shouldn't have. anyway, the bug it fixes somehow only showed up once i updated to android P.