### PR TITLE
Allow backups

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
 
     <application
         android:name=".Weechat"
-        android:allowBackup="false"
+        android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/Weechat"


### PR DESCRIPTION
Super simple change that will make my life much easier as someone that does rom development and needs to be able to hop phones quickly via adb backup/restore.

This is one of the only apps I use that for some reason does not have backups enabled. The user still has to approve on the unlocked device for every backup, so I don't see any security risk here.