### PR TITLE
use buffer font in input bar

### DIFF
--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/ActionEditText.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/ActionEditText.java
@@ -5,18 +5,27 @@ import androidx.appcompat.widget.AppCompatEditText;
 import android.util.AttributeSet;
 import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputConnection;
+import android.widget.TextView;
+
+import com.ubergeek42.WeechatAndroid.service.P;
 
 public class ActionEditText extends AppCompatEditText {
+    public void setFont() {
+        ((TextView) this).setTypeface(P.typeface);
+    }
     public ActionEditText(Context context) {
         super(context);
+        setFont();
     }
 
     public ActionEditText(Context context, AttributeSet attrs) {
         super(context, attrs);
+        setFont();
     }
 
     public ActionEditText(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        setFont();
     }
 
     @Override

--- a/app/src/main/res/layout/chatview_main.xml
+++ b/app/src/main/res/layout/chatview_main.xml
@@ -17,6 +17,7 @@
 
         <com.ubergeek42.WeechatAndroid.utils.ActionEditText
             android:id="@+id/chatview_input"
+            android:fontFamily="monospace"
             android:layout_weight="1.0"
             android:layout_width="0dp"
             android:layout_height="wrap_content"


### PR DESCRIPTION
not sure if this is the desired behavior, but the clash between buffer and input bar fonts was bugging me. 

if it's useful, great; otherwise i'll just keep using it for myself.