### PR TITLE
Add option to display buffers in hierarchical order

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -32,7 +32,6 @@ tasks.withType(JavaCompile) {
 
 android {
     compileSdkVersion 27
-    buildToolsVersion "27.0.3"
 
     defaultConfig {
         versionCode 437

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/adapters/BufferListAdapter.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/adapters/BufferListAdapter.java
@@ -86,7 +86,7 @@ public class BufferListAdapter extends RecyclerView.Adapter<ViewHolder> implemen
 
         @MainThread void update(VisualBuffer buffer) {
             fullName = buffer.fullName;
-            uiBuffer.setText(P.hierarchicalBuffers ? buffer.printableHierarchical : buffer.printable);
+            uiBuffer.setText(P.hierarchicalBuffers && !isFiltered() ? buffer.printableHierarchical : buffer.printable);
             int unreads = buffer.unreads;
             int highlights = buffer.highlights;
 
@@ -176,6 +176,10 @@ public class BufferListAdapter extends RecyclerView.Adapter<ViewHolder> implemen
     @AnyThread synchronized public static void setFilter(final String s) {
         P.filterLc = s.toLowerCase();
         P.filterUc = s.toUpperCase();
+    }
+
+    @AnyThread synchronized public static boolean isFiltered() {
+        return P.filterLc != null && !P.filterLc.equals("");
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -289,6 +293,15 @@ public class BufferListAdapter extends RecyclerView.Adapter<ViewHolder> implemen
             if(buffer.rootBufferFullName != null) {
                 // Requires each root buffer to exists. Otherwise a NPE will be thrown
                 // (which is under no circumstances expected).
+
+
+                if(!bufferMap.containsKey(buffer.rootBufferFullName)) {
+                    // The list is currently being filtered
+                    // Can't do the intended sort and just sort alphabetically.
+                    Collections.sort(buffers, sortByName);
+                    return;
+                }
+
                 bufferMap.get(buffer.rootBufferFullName).add(buffer);
             }
         }

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
@@ -85,6 +85,7 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
     public static float _200dp;
 
     public static boolean sortBuffers;
+    public static boolean hierarchicalBuffers;
     public static boolean filterBuffers;
     public static boolean hideHiddenBuffers;
     public static boolean optimizeTraffic;
@@ -115,6 +116,7 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
     @MainThread private static void loadUIPreferences() {
         // buffer list preferences
         sortBuffers = p.getBoolean(PREF_SORT_BUFFERS, PREF_SORT_BUFFERS_D);
+        hierarchicalBuffers = p.getBoolean(PREF_HIERARCHICAL_BUFFERS, PREF_HIERARCHICAL_BUFFERS_D);
         filterBuffers = p.getBoolean(PREF_FILTER_NONHUMAN_BUFFERS, PREF_FILTER_NONHUMAN_BUFFERS_D);
         hideHiddenBuffers = p.getBoolean(PREF_HIDE_HIDDEN_BUFFERS, PREF_HIDE_HIDDEN_BUFFERS_D);
         optimizeTraffic = p.getBoolean(PREF_OPTIMIZE_TRAFFIC, PREF_OPTIMIZE_TRAFFIC_D);  // okay this is out of sync with onChanged stuff—used for the bell icon
@@ -220,6 +222,7 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
         switch (key) {
             // buffer list preferences
             case PREF_SORT_BUFFERS: sortBuffers = p.getBoolean(key, PREF_SORT_BUFFERS_D); break;
+            case PREF_HIERARCHICAL_BUFFERS: hierarchicalBuffers = p.getBoolean(key, PREF_HIERARCHICAL_BUFFERS_D); break;
             case PREF_FILTER_NONHUMAN_BUFFERS: filterBuffers = p.getBoolean(key, PREF_FILTER_NONHUMAN_BUFFERS_D); break;
             case PREF_HIDE_HIDDEN_BUFFERS: hideHiddenBuffers = p.getBoolean(key, PREF_HIDE_HIDDEN_BUFFERS_D); break;
             case PREF_AUTO_HIDE_ACTIONBAR: autoHideActionbar = p.getBoolean(key, PREF_AUTO_HIDE_ACTIONBAR_D); break;

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/Constants.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/Constants.java
@@ -46,6 +46,7 @@ public class Constants {
 
     // buffer list
     public static final String PREF_SORT_BUFFERS = "sort_buffers"; final public static boolean PREF_SORT_BUFFERS_D = false;
+    public static final String PREF_HIERARCHICAL_BUFFERS = "hierarchical_buffers"; final public static boolean PREF_HIERARCHICAL_BUFFERS_D = false;
     public static final String PREF_HIDE_HIDDEN_BUFFERS = "hide_hidden_buffers"; final public static boolean PREF_HIDE_HIDDEN_BUFFERS_D = false;
     public static final String PREF_FILTER_NONHUMAN_BUFFERS = "filter_nonhuman_buffers"; final public static boolean PREF_FILTER_NONHUMAN_BUFFERS_D = false;
     public static final String PREF_SHOW_BUFFER_FILTER = "show_buffer_filter"; final public static boolean PREF_SHOW_BUFFER_FILTER_D = false;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -213,6 +213,8 @@
         <string name="pref_bufferlist_group">Buffer list</string>
             <string name="pref_sort_buffers">Sort buffer list</string>
             <string name="pref_sort_buffers_summary">Sort by number of highlights/private messages/unread messages</string>
+            <string name="pref_hierarchical_buffers">Hierarchical buffers</string>
+            <string name="pref_hierarchical_buffers_summary">Display buffers in hierarchy. Overrides sort buffer list!</string>
             <string name="pref_hide_server_buffers">Hide non-conversation buffers</string>
             <string name="pref_hide_server_buffers_summary">E.g. server buffers and plugin buffers</string>
             <string name="pref_hide_hidden_buffers">Hide hidden buffers</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -48,7 +48,8 @@
     <!-- buffer list -->
 
     <PreferenceScreen android:key="bufferlist_group" android:title="@string/pref_bufferlist_group">
-		<CheckBoxPreference android:key="sort_buffers" android:summary="@string/pref_sort_buffers_summary" android:title="@string/pref_sort_buffers" android:defaultValue="false" />
+        <CheckBoxPreference android:key="sort_buffers" android:summary="@string/pref_sort_buffers_summary" android:title="@string/pref_sort_buffers" android:defaultValue="false" />
+        <CheckBoxPreference android:key="hierarchical_buffers" android:summary="@string/pref_hierarchical_buffers_summary" android:title="@string/pref_hierarchical_buffers" android:defaultValue="false" />
 		<CheckBoxPreference android:key="filter_nonhuman_buffers" android:title="@string/pref_hide_server_buffers" android:summary="@string/pref_hide_server_buffers_summary" android:defaultValue="false" />
         <CheckBoxPreference android:key="hide_hidden_buffers" android:title="@string/pref_hide_hidden_buffers" android:summary="@string/pref_hide_hidden_buffers_summary" android:defaultValue="false" />
 		<CheckBoxPreference android:key="show_buffer_filter" android:title="@string/pref_show_buffer_filter" android:summary="@string/pref_show_buffer_filter_summary"  android:defaultValue="false" />

--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.4.2'
         classpath 'org.aspectj:aspectjtools:1.8.6'
     }
 }

--- a/cats/build.gradle
+++ b/cats/build.gradle
@@ -14,7 +14,11 @@ dependencies {
 
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+
+    defaultConfig {
+        minSdkVersion 16
+        targetSdkVersion 27
+    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/cats/src/main/AndroidManifest.xml
+++ b/cats/src/main/AndroidManifest.xml
@@ -1,7 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.ubergeek42.cats">
 
-    <uses-sdk android:minSdkVersion="16"
-    android:targetSdkVersion="27" />
 
 </manifest>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 25 14:53:54 EET 2017
+#Thu Oct 31 00:38:20 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/relay/src/test/java/com/ubergeek42/weechat/relay/protocol/DataTest.java
+++ b/relay/src/test/java/com/ubergeek42/weechat/relay/protocol/DataTest.java
@@ -2,8 +2,8 @@ package com.ubergeek42.weechat.relay.protocol;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;


### PR DESCRIPTION
This modification allows the buffer sidebar to display hierarchical. The list will be sorted alphabetically by full buffer names and have channels appear as child items (just indented with 5 spaces).

That option can be enabled in "Buffer list" preferences and overrides the "sort buffer list" preference. Ideally this would be in a radio dialog. But I currently didn't have the time for that.
![New option](https://user-images.githubusercontent.com/22298664/67918328-2b36ea80-fb9c-11e9-88b1-a6a81797077a.png)

That option doesn't have an french translation.

The after enabling the new option, the buffer list will look like this.
(The order is the same as Glowing-Bear uses.)
![Buffer list with option enabled](https://user-images.githubusercontent.com/22298664/67918322-240fdc80-fb9c-11e9-81c1-72ea01c6cb7c.png)

When filtering, the list will in most cases fall back to alphabetical sort and be flattened again. Though keeping the root items of filtered ones could also be implemented.

There were also some problems compiling the app, which I took care of first.

---

One additonal note would be that **the app crashed** when encountering an "untrusted cert". The F-Droid release gave me a dialog for that, but for me that only worked with the dev build on my machine. Every other build crashed with that message when connecting with WeeChat SSL:
```
2019-10-31 04:32:51.751 6820-6844/? E/🐶: con0 : AbstractConnection connectOnce(): exception while state == CONNECTING
    javax.net.ssl.SSLHandshakeException: java.security.cert.CertPathValidatorException: Trust anchor for certification path not found.
        at com.android.org.conscrypt.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:355)
        at android.net.SSLCertificateSocketFactory.verifyHostname(SSLCertificateSocketFactory.java:200)
        at android.net.SSLCertificateSocketFactory.createSocket(SSLCertificateSocketFactory.java:445)
        at com.ubergeek42.weechat.relay.connection.SSLConnection.doConnect(SSLConnection.java:3)
        at com.ubergeek42.weechat.relay.connection.AbstractConnection.connectOnce(AbstractConnection.java:1)
        at com.ubergeek42.weechat.relay.connection.AbstractConnection.access$100(AbstractConnection.java:1)
        at com.ubergeek42.weechat.relay.connection.AbstractConnection$1.run(AbstractConnection.java:1)
        at java.lang.Thread.run(Thread.java:764)
     Caused by: java.security.cert.CertificateException: java.security.cert.CertPathValidatorException: Trust anchor for certification path not found.
        at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:644)
        at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:493)
        at com.android.org.conscrypt.TrustManagerImpl.checkServerTrusted(TrustManagerImpl.java:319)
        at android.security.net.config.NetworkSecurityTrustManager.checkServerTrusted(NetworkSecurityTrustManager.java:113)
        at android.security.net.config.NetworkSecurityTrustManager.checkServerTrusted(NetworkSecurityTrustManager.java:87)
        at android.security.net.config.RootTrustManager.checkServerTrusted(RootTrustManager.java:116)
        at com.ubergeek42.WeechatAndroid.service.SSLHandler$UserTrustManager.checkServerTrusted(SSLHandler.java:4)
        at com.android.org.conscrypt.Platform.checkServerTrusted(Platform.java:207)
        at com.android.org.conscrypt.OpenSSLSocketImpl.verifyCertificateChain(OpenSSLSocketImpl.java:592)
        at com.android.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
        at com.android.org.conscrypt.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:351)
        at android.net.SSLCertificateSocketFactory.verifyHostname(SSLCertificateSocketFactory.java:200) 
        at android.net.SSLCertificateSocketFactory.createSocket(SSLCertificateSocketFactory.java:445) 
        at com.ubergeek42.weechat.relay.connection.SSLConnection.doConnect(SSLConnection.java:3) 
        at com.ubergeek42.weechat.relay.connection.AbstractConnection.connectOnce(AbstractConnection.java:1) 
        at com.ubergeek42.weechat.relay.connection.AbstractConnection.access$100(AbstractConnection.java:1) 
        at com.ubergeek42.weechat.relay.connection.AbstractConnection$1.run(AbstractConnection.java:1) 
        at java.lang.Thread.run(Thread.java:764) 
     Caused by: java.security.cert.CertPathValidatorException: Trust anchor for certification path not found.
        at com.android.org.conscrypt.TrustManagerImpl.checkTrustedRecursive(TrustManagerImpl.java:644) 
        at com.android.org.conscrypt.TrustManagerImpl.checkTrusted(TrustManagerImpl.java:493) 
        at com.android.org.conscrypt.TrustManagerImpl.checkServerTrusted(TrustManagerImpl.java:319) 
        at android.security.net.config.NetworkSecurityTrustManager.checkServerTrusted(NetworkSecurityTrustManager.java:113) 
        at android.security.net.config.NetworkSecurityTrustManager.checkServerTrusted(NetworkSecurityTrustManager.java:87) 
        at android.security.net.config.RootTrustManager.checkServerTrusted(RootTrustManager.java:116) 
        at com.ubergeek42.WeechatAndroid.service.SSLHandler$UserTrustManager.checkServerTrusted(SSLHandler.java:4) 
        at com.android.org.conscrypt.Platform.checkServerTrusted(Platform.java:207) 
        at com.android.org.conscrypt.OpenSSLSocketImpl.verifyCertificateChain(OpenSSLSocketImpl.java:592) 
        at com.android.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method) 
        at com.android.org.conscrypt.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:351) 
        at android.net.SSLCertificateSocketFactory.verifyHostname(SSLCertificateSocketFactory.java:200) 
        at android.net.SSLCertificateSocketFactory.createSocket(SSLCertificateSocketFactory.java:445) 
        at com.ubergeek42.weechat.relay.connection.SSLConnection.doConnect(SSLConnection.java:3) 
        at com.ubergeek42.weechat.relay.connection.AbstractConnection.connectOnce(AbstractConnection.java:1) 
        at com.ubergeek42.weechat.relay.connection.AbstractConnection.access$100(AbstractConnection.java:1) 
        at com.ubergeek42.weechat.relay.connection.AbstractConnection$1.run(AbstractConnection.java:1) 
        at java.lang.Thread.run(Thread.java:764) 
2019-10-31 04:32:51.979 6820-6820/? E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.ubergeek42.WeechatAndroid, PID: 6820
    java.lang.NoSuchFieldError: No static field DIGITS_LOWER of type [C in class Lorg/apache/commons/codec/binary/Hex; or its superclasses (declaration of 'org.apache.commons.codec.binary.Hex' appears in /system/framework/org.apache.http.legacy.boot.jar)
        at com.ubergeek42.WeechatAndroid.utils.UntrustedCertificateDialog.onCreateDialog(UntrustedCertificateDialog.java:7)
        at android.support.v4.app.DialogFragment.onGetLayoutInflater(DialogFragment.java:3)
        at android.support.v4.app.Fragment.performGetLayoutInflater(Fragment.java:1)
        at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:83)
        at android.support.v4.app.FragmentManagerImpl.moveFragmentToExpectedState(FragmentManager.java:6)
        at android.support.v4.app.FragmentManagerImpl.moveToState(FragmentManager.java:189)
        at android.support.v4.app.BackStackRecord.executeOps(BackStackRecord.java:24)
        at android.support.v4.app.FragmentManagerImpl.executeOpsTogether(FragmentManager.java:50)
        at android.support.v4.app.FragmentManagerImpl.removeRedundantOperationsAndExecute(FragmentManager.java:10)
        at android.support.v4.app.FragmentManagerImpl.execPendingActions(FragmentManager.java:4)
        at android.support.v4.app.FragmentManagerImpl$1.run(FragmentManager.java:1)
        at android.os.Handler.handleCallback(Handler.java:789)
        at android.os.Handler.dispatchMessage(Handler.java:98)
        at android.os.Looper.loop(Looper.java:164)
        at android.app.ActivityThread.main(ActivityThread.java:6709)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.Zygote$MethodAndArgsCaller.run(Zygote.java:240)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:769)
```
The funny thing is, that the cert shouldn't be invalid at all. The cert is from Let's Encrypt and was intended for an HTTPS-Server. I only use it on a non-standard port.

Since I didn't change anything in that area, it isn't probably a result of my changes. Probably some tightened security guidelines on androids side or a more specific build.