### PR TITLE
Look & feel: Sort open buffers by WeeChat order

### DIFF
--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/adapters/MainPagerAdapter.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/adapters/MainPagerAdapter.java
@@ -55,6 +55,7 @@ public class MainPagerAdapter extends PagerAdapter {
         Buffer buffer = BufferList.findByFullName(name);
         if (buffer != null) buffer.setOpen(true);
         names.add(name);
+        if (P.sortOpenBuffers) BufferList.sortFullNames(names);
         notifyDataSetChanged();
         P.setBufferOpen(name, true);
     }

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/BufferList.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/BufferList.java
@@ -27,8 +27,12 @@ import com.ubergeek42.weechat.relay.protocol.RelayObject;
 import org.junit.Assert;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static com.ubergeek42.WeechatAndroid.service.Events.SendMessageEvent;
@@ -129,6 +133,24 @@ public class BufferList {
         if (fullName == null) return null;
         for (Buffer buffer : buffers) if (buffer.fullName.equals(fullName)) return buffer;
         return null;
+    }
+
+    @AnyThread synchronized static public void sortFullNames(@NonNull List<String> fullNamesList) {
+        final HashMap<String,Integer> bufferNumbers = new HashMap<String,Integer>();
+
+        for (Buffer buffer : buffers) bufferNumbers.put(buffer.fullName, buffer.number);
+
+        Comparator<String> sortByNumberComparator = new Comparator<String>() {
+            @Override public int compare(String left, String right) {
+                Integer l = bufferNumbers.get(left);
+                Integer r = bufferNumbers.get(right);
+                if (l == null) l = Integer.MAX_VALUE;
+                if (r == null) r = Integer.MAX_VALUE;
+                return l.compareTo(r);
+            }
+        };
+
+        Collections.sort(fullNamesList, sortByNumberComparator);
     }
 
     @AnyThread static public void setBufferListEye(@Nullable BufferListEye buffersEye) {

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
@@ -88,6 +88,7 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
     public static boolean filterBuffers;
     public static boolean hideHiddenBuffers;
     public static boolean optimizeTraffic;
+    public static boolean sortOpenBuffers;
     public static boolean filterLines, autoHideActionbar;
     public static int maxWidth;
     public static boolean encloseNick, dimDownNonHumanLines;
@@ -118,6 +119,7 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
         filterBuffers = p.getBoolean(PREF_FILTER_NONHUMAN_BUFFERS, PREF_FILTER_NONHUMAN_BUFFERS_D);
         hideHiddenBuffers = p.getBoolean(PREF_HIDE_HIDDEN_BUFFERS, PREF_HIDE_HIDDEN_BUFFERS_D);
         optimizeTraffic = p.getBoolean(PREF_OPTIMIZE_TRAFFIC, PREF_OPTIMIZE_TRAFFIC_D);  // okay this is out of sync with onChanged stuff—used for the bell icon
+        sortOpenBuffers = p.getBoolean(PREF_SORT_OPEN_BUFFERS, PREF_SORT_OPEN_BUFFERS_D);
 
         // buffer-wide preferences
         filterLines = p.getBoolean(PREF_FILTER_LINES, PREF_FILTER_LINES_D);
@@ -223,6 +225,7 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
             case PREF_FILTER_NONHUMAN_BUFFERS: filterBuffers = p.getBoolean(key, PREF_FILTER_NONHUMAN_BUFFERS_D); break;
             case PREF_HIDE_HIDDEN_BUFFERS: hideHiddenBuffers = p.getBoolean(key, PREF_HIDE_HIDDEN_BUFFERS_D); break;
             case PREF_AUTO_HIDE_ACTIONBAR: autoHideActionbar = p.getBoolean(key, PREF_AUTO_HIDE_ACTIONBAR_D); break;
+            case PREF_SORT_OPEN_BUFFERS: sortOpenBuffers = p.getBoolean(key, PREF_SORT_OPEN_BUFFERS_D); break;
 
             // buffer-wide preferences
             case PREF_FILTER_LINES:

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/Constants.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/Constants.java
@@ -60,6 +60,7 @@ public class Constants {
     public static final String PREF_ENCLOSE_NICK = "enclose_nick"; final public static boolean PREF_ENCLOSE_NICK_D = false;
     final static public String PREF_TIMESTAMP_FORMAT = "timestamp_format"; final public static String PREF_TIMESTAMP_FORMAT_D = "HH:mm:ss";
     public static final String PREF_DIM_DOWN = "dim_down"; final public static boolean PREF_DIM_DOWN_D = false;
+    public static final String PREF_SORT_OPEN_BUFFERS = "sort_open_buffers"; final public static boolean PREF_SORT_OPEN_BUFFERS_D = false;
     public static final String PREF_BUFFER_FONT = "buffer_font"; final public static String PREF_BUFFER_FONT_D = "";
     public static final String PREF_COLOR_SCHEME = "color_scheme"; final public static String PREF_COLOR_SCHEME_D = "default-theme.properties";
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -250,6 +250,8 @@
             <string name="pref_timestamp_format_summary">%s (default: HH:mm:ss)</string>
             <string name="pref_dim_down">Dim down non-human lines</string>
             <string name="pref_dim_down_summary">Display joins/quits in a darker color</string>
+            <string name="pref_sort_open_buffers">Sort open buffers</string>
+            <string name="pref_sort_open_buffers_summary">Sort open buffers by WeeChat order</string>
 
             <string name="pref_font">Buffer Font</string>
             <string name="pref_color_scheme">Color Scheme</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -65,6 +65,7 @@
         <CheckBoxPreference android:key="enclose_nick" android:title="@string/pref_enclose_nick" android:summary="@string/pref_enclose_nick_summary" android:defaultValue="false" />
 		<EditTextPreferenceFix android:key="timestamp_format" android:title="@string/pref_timestamp_format" android:summary="@string/pref_timestamp_format_summary" android:defaultValue="HH:mm:ss" android:singleLine="true" />
         <CheckBoxPreference android:key="dim_down" android:title="@string/pref_dim_down" android:summary="@string/pref_dim_down_summary" android:defaultValue="false" />
+        <CheckBoxPreference android:key="sort_open_buffers" android:title="@string/pref_sort_open_buffers" android:summary="@string/pref_sort_open_buffers_summary" android:defaultValue="false" />
 	    <FontPreference android:key="buffer_font" android:title="@string/pref_font" />
 	    <ThemePreference android:key="color_scheme" android:title="@string/pref_color_scheme" android:defaultValue="default-theme.properties" />
     </PreferenceScreen>


### PR DESCRIPTION
This adds an option to sort the open buffers by WeeChat order.

It got frustrating to have the buffers be in the order I happened to open them so this makes them consistent and match the order I know from WeeChat itself.