### PR TITLE
Don't strip apache lib for SSL on Android 6

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -44,3 +44,4 @@
 -keepclassmembers class ** {
     public void onEvent*(**);
 }
+-keep class org.apache.commons.codec.digest.* { *; }


### PR DESCRIPTION
Without this, when connecting to WeeChat SSL, WA dies with: "Cannot
verify hostname".