### PR TITLE
Fix storage access on Android Q

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         android:icon="@mipmap/ic_launcher_kitty"
         android:label="@string/app_name"
         android:theme="@style/Weechat"
+        android:requestLegacyExternalStorage="true"
         android:windowSoftInputMode="adjustResize">
         <service android:name=".service.RelayService" />
         <activity

--- a/app/src/main/java/androidx/preference/FontManager.java
+++ b/app/src/main/java/androidx/preference/FontManager.java
@@ -4,21 +4,33 @@
 
 package androidx.preference;
 
+import android.content.Context;
 import android.graphics.Typeface;
 import android.os.Environment;
+
 import androidx.annotation.NonNull;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedList;
+import java.util.List;
 
 class FontManager {
-    final static String[] FONT_DIRS = {Environment.getExternalStorageDirectory().toString() + "/weechat", "/system/fonts"};
+    static List<String> getFontSearchDirectories(Context context) {
+        List<String> out = new ArrayList<>(Arrays.asList("/system/fonts",
+                Environment.getExternalStorageDirectory().toString() + "/weechat"));
+        File appSpecificFontFolder = context.getExternalFilesDir("fonts");
+        if (appSpecificFontFolder != null)
+            out.add(appSpecificFontFolder.toString());
+        return out;
+    }
 
-    static @NonNull LinkedList<FontInfo> enumerateFonts() {
+    static @NonNull LinkedList<FontInfo> enumerateFonts(Context context) {
         LinkedList<FontInfo> fonts = new LinkedList<>();
 
-        for (String fontdir : FONT_DIRS) {
-            File dir = new File(fontdir);
+        for (String directory : getFontSearchDirectories(context)) {
+            File dir = new File(directory);
             if (!dir.exists()) continue;
             File[] files = dir.listFiles();
             if (files == null) continue;

--- a/app/src/main/java/androidx/preference/FontPreference.java
+++ b/app/src/main/java/androidx/preference/FontPreference.java
@@ -4,9 +4,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.graphics.Typeface;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.appcompat.app.AlertDialog;
-
 import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -14,6 +11,10 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 import android.widget.CheckedTextView;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
 
 import com.ubergeek42.WeechatAndroid.R;
 import com.ubergeek42.WeechatAndroid.utils.Constants;
@@ -41,7 +42,7 @@ public class FontPreference extends DialogPreference {
 
     @Override public CharSequence getSummary() {
         StringBuilder sb = new StringBuilder();
-        for (String p: FontManager.FONT_DIRS)
+        for (String p: FontManager.getFontSearchDirectories(getContext()))
             sb.append("\n    ").append(p);
         return getContext().getString(R.string.pref_font_summary,
                 sb.toString(),
@@ -67,7 +68,7 @@ public class FontPreference extends DialogPreference {
             super.onPrepareDialogBuilder(builder);
 
             inflater = (LayoutInflater) requireContext().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-            fonts = FontManager.enumerateFonts();
+            fonts = FontManager.enumerateFonts(requireContext());
             Collections.sort(fonts);
 
             // add a "fake" default monospace font
@@ -123,5 +124,11 @@ public class FontPreference extends DialogPreference {
                 return view;
             }
         }
+    }
+
+    @Override public void onBindViewHolder(PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        TextView summary = (TextView) holder.findViewById(android.R.id.summary);
+        summary.setMaxHeight(Integer.MAX_VALUE);
     }
 }

--- a/app/src/main/java/androidx/preference/ThemePreferenceHelp.java
+++ b/app/src/main/java/androidx/preference/ThemePreferenceHelp.java
@@ -15,12 +15,17 @@ public class ThemePreferenceHelp extends Preference {
     }
 
     @Override public CharSequence getSummary() {
-        return Html.fromHtml(getContext().getString(R.string.pref_theme_help, ThemeManager.SEARCH_DIR));
+        StringBuilder sb = new StringBuilder();
+        for (String p: ThemeManager.getThemeSearchDirectories(getContext()))
+            sb.append("<br>&nbsp;&nbsp;&nbsp;&nbsp;").append(p);
+
+        return Html.fromHtml(getContext().getString(R.string.pref_theme_help, sb));
     }
 
     @Override public void onBindViewHolder(PreferenceViewHolder holder) {
         super.onBindViewHolder(holder);
         TextView summary = (TextView) holder.findViewById(android.R.id.summary);
         summary.setMovementMethod(LinkMovementMethod.getInstance());
+        summary.setMaxHeight(Integer.MAX_VALUE);
     }
 }

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -150,7 +150,7 @@
   <string name="pref_font">Police des tampons</string>
   <string name="pref_theme_loading_error">Erreur lors du chargement du thème %s</string>
   <string name="pref_theme_not_set">Indéfini</string>
-  <string name="pref_font_summary">L\'alignement fonctionne mal avec les polices non-monospace.\n\nChemin de recherche :%1$s\n\nValeur actuelle :\n    %2$s</string>
+  <string name="pref_font_summary">L\'alignement fonctionne mal avec les polices non-monospace. Chemins de recherche :%1$s\n\nValeur actuelle :\n    %2$s</string>
   <string name="pref_font_default">Par défaut</string>
   <string name="pref_button_group">Boutons</string>
   <string name="pref_tabbtn_show">Afficher le bouton tab</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -97,7 +97,7 @@
          приложения. Поменяйте цвета интерфейса приложения, цвета своих и помеченных сообщений,
          измените цветовую палитру WeeChat! <a
                 href="https://github.com/ubergeek42/weechat-android/wiki/Custom-Color-Schemes">Больше
-                информации</a><br><br>Поместите свои цветовые схемы сюда:<br>&nbsp;&nbsp;&nbsp;&nbsp;%1$s]]></string>
+                информации</a><br><br>Поместите свои цветовые схемы в одну из этих папок:%1$s]]></string>
     <string name="pref_timestamp_format">Формат времени</string>
     <string name="pref_timestamp_format_summary">%s (по умолчанию: HH:mm:ss)</string>
     <string name="pref_timestamp_invalid">Неверный формат времени</string>
@@ -182,7 +182,7 @@
     <string name="pref_enclose_nick_summary">Отображать символы &lt; и &gt; вокруг ников</string>
     <string name="pref_font">Шрифт буфера</string>
     <string name="pref_font_default">По умолчанию</string>
-    <string name="pref_font_summary">Пропорциональные шрифты лучше не смешивать с выравниванием.\n\nПуть поиска:%1$s\n\nТекущий шрифт:\n\u0020\u0020\u0020\u0020%2$s</string>
+    <string name="pref_font_summary">Пропорциональные шрифты лучше не смешивать с выравниванием. Пути поиска:%1$s\n\nТекущий шрифт:\n\u0020\u0020\u0020\u0020%2$s</string>
     <string name="pref_hide_hidden_buffers">Скрывать скрытые буферы</string>
     <string name="pref_hide_hidden_buffers_summary">Скрывать буферы, скрытые командой /buffer hide</string>
     <string name="pref_hide_server_buffers">Скрывать буферы без людей</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -271,11 +271,11 @@
                 application. Use arbitrary colors for UI elements, customize highlight and
                 read marker color, change the WeeChat color palette! <a
                 href="https://github.com/ubergeek42/weechat-android/wiki/Custom-Color-Schemes">Learn
-                more</a><br><br>Put your custom color scheme here:<br>&nbsp;&nbsp;&nbsp;&nbsp;%1$s]]></string>
+                more</a><br><br>Put your custom color scheme in any of these folders:%1$s]]></string>
             <string name="pref_theme_not_set">Not set</string>
 
             <!-- font -->
-            <string name="pref_font_summary">Non-monospace fonts will not work well with alignment.\n\nSearch Path:%1$s\n\nCurrent Value:\n\u0020\u0020\u0020\u0020%2$s</string>
+            <string name="pref_font_summary">Non-monospace fonts will not work well with alignment. Search path:%1$s\n\nCurrent font:\n\u0020\u0020\u0020\u0020%2$s</string>
             <string name="pref_font_default">Default</string>
 
     <!-- buttons -->


### PR DESCRIPTION
Android Q denies access to external storage to apps by default.

This will request legacy storage access. Also, it allows loading files from app-specific directory (e.g. `/storage/emulated/0/Android/data/com.ubergeek42.WeechatAndroid/files/fonts`).

Loading files from `weechat` folder can be perhaps removed altogether later on along with the storage permission.

