### PR TITLE
Fix display of version on startup

### DIFF
--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/CutePagerTitleStrip.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/CutePagerTitleStrip.java
@@ -248,6 +248,7 @@ public class CutePagerTitleStrip extends ViewGroup {
 
     public void setEmptyText(@Nullable String text) {
         mEmptyText = text;
+        updateText();
     }
 
     public void updateText() {


### PR DESCRIPTION
Update the displayed text when the empty text is set, otherwise it won't happen until connecting causes an update.