### PR TITLE
Support keys in PKCS#8 format

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -66,3 +66,53 @@
 -keepclasseswithmembers class com.ubergeek42.weechat.** {
     kotlinx.serialization.KSerializer serializer(...);
 }
+
+# the following are rules that are needed for PEM/PKCS #8 decoding (AndroidKeyStoreUtils.kt)
+# these have been roughly determined by placing a logging break point on:
+#   java.lang.ClassLoader.loadClass(java.lang.String, boolean)
+-keep class org.bouncycastle.jcajce.provider.digest.MD2** { *; }
+-keep class org.bouncycastle.jcajce.provider.digest.MD4** { *; }
+-keep class org.bouncycastle.jcajce.provider.digest.MD5** { *; }
+-keep class org.bouncycastle.jcajce.provider.digest.SHA1** { *; }
+-keep class org.bouncycastle.jcajce.provider.digest.SHA224** { *; }
+-keep class org.bouncycastle.jcajce.provider.digest.SHA256** { *; }
+-keep class org.bouncycastle.jcajce.provider.digest.SHA384** { *; }
+-keep class org.bouncycastle.jcajce.provider.digest.SHA512** { *; }
+
+-keep class org.bouncycastle.jcajce.provider.symmetric.PBEPBKDF1** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.PBEPBKDF2** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.PBEPKCS12** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.AES** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.ARC4** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.ARIA** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.Blowfish** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.Camellia** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.DES** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.DESede** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.IDEA** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.RC2** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.RC5** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.RC6** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.Twofish** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.Threefish** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.OpenSSLPBKDF** { *; }
+
+-keep class org.bouncycastle.jcajce.provider.asymmetric.DSA$Mappings { *; }
+-keep class org.bouncycastle.jcajce.provider.asymmetric.EC$Mappings { *; }
+-keep class org.bouncycastle.jcajce.provider.asymmetric.RSA$Mappings { *; }
+-keep class org.bouncycastle.jcajce.provider.asymmetric.EdEC$Mappings { *; }
+
+-keep class org.bouncycastle.jcajce.provider.keystore.BC$Mappings { *; }
+-keep class org.bouncycastle.jcajce.provider.keystore.BCFKS$Mappings { *; }
+-keep class org.bouncycastle.jcajce.provider.keystore.PKCS12$Mappings { *; }
+
+-keep class org.bouncycastle.jcajce.provider.asymmetric.dsa.KeyFactorySpi { *; }
+-keep class org.bouncycastle.jcajce.provider.asymmetric.rsa.KeyFactorySpi { *; }
+-keep class org.bouncycastle.jcajce.provider.asymmetric.ec.KeyFactorySpi** { *; }
+-keep class org.bouncycastle.jcajce.provider.asymmetric.edec.KeyFactorySpi** { *; }
+-keep class org.bouncycastle.jcajce.provider.asymmetric.edec.KeyFactorySpi** { *; }
+
+-keep class org.bouncycastle.jcajce.provider.drbg.DRBG$Mappings { *; }
+-keep class javax.crypto.spec.GCMParameterSpec { *; }
+-keep class org.bouncycastle.openssl.jcajce.PEMUtilities** { *; }
+-keep class org.bouncycastle.jcajce.provider.symmetric.util.IvAlgorithmParameters { *; }

--- a/app/src/main/java/androidx/preference/PrivateKeyPickerPreference.java
+++ b/app/src/main/java/androidx/preference/PrivateKeyPickerPreference.java
@@ -9,6 +9,7 @@ import androidx.annotation.Nullable;
 import com.ubergeek42.WeechatAndroid.R;
 import com.ubergeek42.WeechatAndroid.utils.TinyMap;
 import com.ubergeek42.WeechatAndroid.utils.Utils;
+import com.ubergeek42.WeechatAndroid.utils.AndroidKeyStoreUtilsKt;
 import com.ubergeek42.cats.Kitty;
 import com.ubergeek42.cats.Root;
 import com.ubergeek42.weechat.relay.connection.SSHConnection;
@@ -36,7 +37,14 @@ public class PrivateKeyPickerPreference extends PasswordedFilePickerPreference {
         String key, message;
 
         if (bytes != null) {
-            KeyPair keyPair = SSHConnection.makeKeyPair(bytes, passphrase);
+            KeyPair keyPair;
+            try {
+                keyPair = SSHConnection.makeKeyPair(bytes, passphrase);
+            } catch (Exception e) {
+                keyPair = AndroidKeyStoreUtilsKt.makeKeyPair(
+                        AndroidKeyStoreUtilsKt.toReader(bytes), passphrase.toCharArray());
+            }
+
             String algorithm = keyPair.getPrivate().getAlgorithm();
 
             try {

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/AndroidKeyStoreUtils.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/AndroidKeyStoreUtils.java
@@ -61,6 +61,7 @@ public class AndroidKeyStoreUtils {
                 signerBuilder = BcRSAContentSignerBuilder::new;
                 break;
             case "EC":
+            case "ECDSA":
                 signingAlgorithm = "SHA256withECDSA";
                 signerBuilder = BcECContentSignerBuilder::new;
                 break;

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/AndroidKeyStoreUtils.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/AndroidKeyStoreUtils.kt
@@ -1,0 +1,95 @@
+@file:Suppress("MoveVariableDeclarationIntoWhen")
+
+package com.ubergeek42.WeechatAndroid.utils
+
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.openssl.PEMEncryptedKeyPair
+import org.bouncycastle.openssl.PEMKeyPair
+import org.bouncycastle.openssl.PEMParser
+import org.bouncycastle.openssl.jcajce.JcaMiscPEMGenerator
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter
+import org.bouncycastle.openssl.jcajce.JceOpenSSLPKCS8DecryptorProviderBuilder
+import org.bouncycastle.openssl.jcajce.JcePEMDecryptorProviderBuilder
+import org.bouncycastle.pkcs.PKCS8EncryptedPrivateKeyInfo
+import org.bouncycastle.util.io.pem.PemWriter
+import java.io.*
+import java.security.KeyPair
+import java.security.PrivateKey
+import kotlin.jvm.Throws
+
+
+private val bouncyCastleProvider = BouncyCastleProvider()
+private val pkcs8DecryptorProvider = JceOpenSSLPKCS8DecryptorProviderBuilder()
+        .setProvider(bouncyCastleProvider)
+private val pemDecryptorProviderBuilder = JcePEMDecryptorProviderBuilder()
+        .setProvider(bouncyCastleProvider)
+
+private val pkcs8pemKeyConverter = JcaPEMKeyConverter().setProvider(bouncyCastleProvider)
+
+// do NOT use BC for converting pkcs1 as for ECDSA it creates keys with algorithm "ECDSA"
+// instead of "EC", and trying to put the former inside AndroidKeyStore results in
+// exception “Unsupported key algorithm: ECDSA”
+private val pkcs1pemKeyConverter = JcaPEMKeyConverter()
+
+
+@Throws(Exception::class)   // this method throws just too many exceptions
+fun makeKeyPair(keyReader: Reader, passphrase: CharArray): KeyPair {
+    val pemObject = PEMParser(keyReader).readObject()
+
+    return when (pemObject) {
+        // encrypted pkcs8 file, header: -----BEGIN ENCRYPTED PRIVATE KEY-----
+        //   $ ssh-keygen -t ecdsa -m pem -N "password" -f ecdsa.pkcs8.password=password
+        // upon decrypting it, we only get a private key. to obtain a key pair, we do something
+        // a bit silly but simple: we convert the decrypted private key back to PEM and run
+        // this method on the resulting data
+        // see this answer by Dave Thompson https://stackoverflow.com/a/57069951/1449683
+        is PKCS8EncryptedPrivateKeyInfo -> {
+            val decryptionProv = pkcs8DecryptorProvider.build(passphrase)
+            val privateKeyInfo = pemObject.decryptPrivateKeyInfo(decryptionProv)
+            val privateKey = pkcs8pemKeyConverter.getPrivateKey(privateKeyInfo)
+            return makeKeyPair(privateKey.toPem().toReader(), passphrase)
+        }
+
+        // unencrypted pkcs8 file, header: -----BEGIN PRIVATE KEY-----
+        //   $ ssh-keygen -t rsa -m pem -N "" -f ecdsa.pkcs8
+        is PrivateKeyInfo -> {
+            val privateKey = pkcs8pemKeyConverter.getPrivateKey(pemObject)
+            return makeKeyPair(privateKey.toPem().toReader(), passphrase)
+        }
+
+        // encrypted pkcs1 file, header like: -----BEGIN RSA PRIVATE KEY-----
+        //                                    Proc-Type: 4,ENCRYPTED
+        //                                    DEK-Info: AES-256-CBC,3B162E06B12794EA105855E7942D5A1A
+        //   $ ssh-keygen -t ecdsa -m pem -N "password" -f ecdsa.pem.password=password
+        //   $ openssl genrsa -aes256 -out openssl.rsa.aes256.password=password -passout pass:password 4096
+        is PEMEncryptedKeyPair -> {
+            val decryptorProvider = pemDecryptorProviderBuilder.build(passphrase)
+            pkcs1pemKeyConverter.getKeyPair(pemObject.decryptKeyPair(decryptorProvider))
+        }
+
+        // unencrypted pkcs1 file, header like: -----BEGIN RSA PRIVATE KEY-----
+        //   $ ssh-keygen -t rsa -m pem -f pem.rsa
+        is PEMKeyPair -> {
+            pkcs1pemKeyConverter.getKeyPair(pemObject)
+        }
+
+        else -> {
+            throw IllegalArgumentException("Don't know how to decode " +
+                    pemObject.javaClass.simpleName)
+        }
+    }
+}
+
+
+@Throws(Exception::class)
+private fun PrivateKey.toPem(): String {
+    val privateKeyPemObject = JcaMiscPEMGenerator(this, null).generate()
+    val stringWriter = StringWriter()
+    PemWriter(stringWriter).use { it.writeObject(privateKeyPemObject) }
+    return stringWriter.toString()
+}
+
+
+fun ByteArray.toReader() = InputStreamReader(ByteArrayInputStream(this))
+fun String.toReader() = StringReader(this)


### PR DESCRIPTION
this requires a few classes from BouncyCastle, apk size +238K

for pkcs1, BC seems to support aes*, des, des3 ciphers, and does not support aria*, camellia* and idea despite including the ciphers

for pkcs8, BC seems to support every cipher from v1 (PBE-MD5-DES, PBE-SHA1-RC2-64, PBE-MD5-RC2-64, PBE-SHA1-DES, PBE-SHA1-RC4-128, PBE-SHA1-RC4-40, PBE-SHA1-3DES, PBE-SHA1-2DES, PBE-SHA1-RC2-128, PBE-SHA1-RC2-40, couldn't test as couldn't generate: PBE-MD2-DES and PBE-MD2-RC2-64) and des3 from v2, but not des or rc2 for some reason

in other words, this should support every PEM key that's created in modern openssh and openssl unless you try to be funny