### PR TITLE
Relay-driven completion >= 2.9 with coroutines to associate the completion request with the response

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.2.0")
     implementation("androidx.preference:preference-ktx:1.1.1")  // preference fragment & al
     implementation("androidx.legacy:legacy-preference-v14:1.0.0") // styling for the fragment
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.2.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1")
 
     implementation("com.github.bumptech.glide:glide:4.11.0")
     kapt("com.github.bumptech.glide:compiler:4.11.0")

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/BufferList.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/BufferList.java
@@ -97,7 +97,13 @@ public class BufferList {
         assertThat(handlers.put(id, handler)).isNull();
     }
 
-    @AnyThread private static void removeMessageHandler(String id, RelayMessageHandler handler) {
+    @AnyThread public static String addOneOffMessageHandler(RelayMessageHandler handler) {
+        String id = String.valueOf(counter++);
+        assertThat(handlers.put(id, handler)).isNull();
+        return id;
+    }
+
+    @AnyThread public static void removeMessageHandler(String id, RelayMessageHandler handler) {
         handlers.remove(id, handler);
     }
 

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/tabcomplete/LocalTabCompleter.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/tabcomplete/LocalTabCompleter.kt
@@ -1,0 +1,72 @@
+package com.ubergeek42.WeechatAndroid.tabcomplete
+
+import android.widget.EditText
+import androidx.lifecycle.Lifecycle
+import com.ubergeek42.WeechatAndroid.relay.Buffer
+import com.ubergeek42.cats.Kitty
+import com.ubergeek42.cats.Root
+import kotlin.properties.Delegates
+
+
+class LocalTabCompleter() : TabCompleter() {
+    @Root
+    private val kitty = Kitty.make()
+
+    private lateinit var tcMatches: ArrayList<String>
+    private var tcIndex by Delegates.notNull<Int>()
+    private var tcWordStart by Delegates.notNull<Int>()
+    private var tcWordEnd by Delegates.notNull<Int>()
+
+    constructor(lifecycle: Lifecycle, buffer: Buffer, uiInput: EditText) : this() {
+        this.lifecycle = lifecycle
+        this.buffer = buffer
+        this.uiInput = uiInput
+    }
+
+    override fun next() {
+        val txt = uiInput.text ?: return
+
+        if (!this::tcMatches.isInitialized) {
+            // find the end of the word to be completed
+            // blabla nick|
+            tcWordEnd = uiInput.selectionStart
+            if (tcWordEnd <= 0) return
+
+            // find the beginning of the word to be completed
+            // blabla |nick
+            tcWordStart = tcWordEnd
+            while (tcWordStart > 0 && txt[tcWordStart - 1] != ' ') tcWordStart--
+
+            // get the word to be completed, lowercase
+            if (tcWordStart == tcWordEnd) return
+            val prefix = txt.subSequence(tcWordStart, tcWordEnd).toString().toLowerCase()
+
+            // compute a list of possible matches
+            // nicks is ordered in last used comes first way, so we just pick whatever comes first
+            // if computed list is empty, abort
+            tcMatches = buffer.getMostRecentNicksMatching(prefix)
+            if (tcMatches.size == 0) return
+            tcIndex = 0
+        } else {
+            if (tcMatches.size == 0) return
+            tcIndex = (tcIndex + 1) % tcMatches.size
+        }
+
+        // get new nickname, adjust the end of the word marker
+        // and finally set the text and place the cursor on the end of completed word
+
+        // get new nickname, adjust the end of the word marker
+        // and finally set the text and place the cursor on the end of completed word
+        var nick = tcMatches[tcIndex]
+        if (tcWordStart == 0) nick += ": "
+        shouldntNullOut = true
+        txt.replace(tcWordStart, tcWordEnd, nick)
+        tcWordEnd = tcWordStart + nick.length
+        uiInput.setSelection(tcWordEnd)
+    }
+
+    override fun cancel() {
+        // no-op
+    }
+
+}

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/tabcomplete/OnlineTabCompleter.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/tabcomplete/OnlineTabCompleter.kt
@@ -1,0 +1,101 @@
+package com.ubergeek42.WeechatAndroid.tabcomplete
+
+import android.widget.EditText
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.coroutineScope
+import com.ubergeek42.WeechatAndroid.Weechat
+import com.ubergeek42.WeechatAndroid.relay.Buffer
+import com.ubergeek42.cats.Kitty
+import com.ubergeek42.cats.Root
+import com.ubergeek42.weechat.relay.protocol.Hdata
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlin.math.min
+import kotlin.properties.Delegates
+
+class OnlineTabCompleter() : TabCompleter() {
+    @Root
+    private val kitty = Kitty.make()
+
+    private lateinit var job: Job;
+
+    private lateinit var tcBaseString: String // the entire original input
+    private var tcIndex by Delegates.notNull<Int>() // index used when looping over tcCompletionResults
+    private lateinit var tcCompletionResults: Array<String>
+    private var tcAddSpace by Delegates.notNull<Boolean>() // to add a space after completion
+    private var tcPosStart by Delegates.notNull<Int>() // beginning of section to be replaced by one of the suggestions
+    private var tcPosEnd by Delegates.notNull<Int>() // end of said section in tcBaseString
+
+    private lateinit var tcBaseWord: String
+    private var tcSelectionIndex by Delegates.notNull<Int>() // where the cursor was when tab was pressed
+
+    constructor(lifecycle: Lifecycle, buffer: Buffer, uiInput: EditText) : this() {
+        this.lifecycle = lifecycle
+        this.buffer = buffer
+        this.uiInput = uiInput
+        this.tcBaseString = uiInput.text.toString()
+        this.tcSelectionIndex = uiInput.selectionStart
+    }
+
+    override fun next() {
+        val txt = uiInput.text ?: return
+
+        if (this::tcCompletionResults.isInitialized) {
+            // tcCompletionResults.size == 0 if exception thrown; null out upon next user input
+            if (tcCompletionResults.size > 1) {
+                val resultsSize = tcCompletionResults.size
+                tcIndex = (tcIndex + 1) % resultsSize
+                shouldntNullOut = true
+                val completionText = tcCompletionResults[tcIndex] + if (tcAddSpace) " " else ""
+                txt.replace(tcPosStart, tcPosEnd, completionText)
+                tcPosEnd = tcPosStart + completionText.length
+            }
+            return
+        }
+
+        cancel() // could be initialized but response hasn't arrived yet (e.g. tab pressed rapidly)
+        job = this.lifecycle.coroutineScope.launch {
+            runCatching {
+                val completionMessage = "completion 0x%x %d %s"
+                        .format(buffer.pointer, uiInput.selectionStart, uiInput.text.toString())
+                val relayObject = sendMessageAndGetResponse(completionMessage) as Hdata
+                kitty.info("got relay completion response: $relayObject")
+
+                if (relayObject.count == 0)
+                    throw NoSuchElementException("No completion results from relay.")
+
+                val item = relayObject.getItem(0)
+                tcCompletionResults =
+                        item.getItem("list").asArray().asStringArray()
+
+                tcAddSpace = item.getItem("add_space").asInt() == 1
+                tcPosStart = item.getItem("pos_start").asInt()
+                tcPosEnd = item.getItem("pos_end").asInt()
+                tcBaseWord = item.getItem("base_word").asString()
+                tcIndex = 0
+
+                if (tcCompletionResults.isEmpty())
+                    throw NoSuchElementException("No completion results from relay.")
+
+                if (!isActive) return@launch
+
+                // let BufferFragment null this out if only one completion result
+                if (tcCompletionResults.size > 1)
+                    shouldntNullOut = true
+
+                Weechat.runOnMainThread {
+                    val completionText = tcCompletionResults[0] + if (tcAddSpace) " " else ""
+                    txt.replace(tcPosStart, min(++tcPosEnd, txt.length), completionText)
+                    tcPosEnd = tcPosStart + completionText.length
+                }
+            }.onFailure { kitty.info("Error while tab completing", it); }
+        }
+    }
+
+    override fun cancel() {
+        if (this::job.isInitialized) {
+            job.cancel()
+        }
+    }
+}

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/tabcomplete/TabCompleter.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/tabcomplete/TabCompleter.kt
@@ -1,0 +1,53 @@
+package com.ubergeek42.WeechatAndroid.tabcomplete
+
+import android.widget.EditText
+import androidx.lifecycle.Lifecycle
+import com.ubergeek42.WeechatAndroid.relay.Buffer
+import com.ubergeek42.WeechatAndroid.relay.BufferList
+import com.ubergeek42.WeechatAndroid.service.Events
+import com.ubergeek42.weechat.relay.RelayMessageHandler
+import com.ubergeek42.weechat.relay.connection.RelayConnection
+import com.ubergeek42.weechat.relay.protocol.RelayObject
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+abstract class TabCompleter {
+
+    lateinit var lifecycle: Lifecycle
+    lateinit var buffer: Buffer // LocalTabCompleter needs access to the buffer
+    lateinit var uiInput: EditText
+
+    var shouldntNullOut = false
+
+    fun shouldntNullOut(): Boolean {
+        val temp = shouldntNullOut
+        shouldntNullOut = false
+        return temp
+    }
+
+    companion object {
+        @JvmStatic
+        fun obtain(lifecycle: Lifecycle, buffer: Buffer, uiInput: EditText): TabCompleter {
+            return if (RelayConnection.weechatVersion >= 0x2090000) {
+                OnlineTabCompleter(lifecycle, buffer, uiInput)
+            } else {
+                LocalTabCompleter(lifecycle, buffer, uiInput)
+            }
+        }
+    }
+
+    abstract fun next()
+    abstract fun cancel()
+
+    suspend fun sendMessageAndGetResponse(message: String) = suspendCancellableCoroutine<RelayObject> {
+        val handler = object : RelayMessageHandler {
+            override fun handleMessage(obj: RelayObject, id: String) {
+                it.resume(obj)
+                BufferList.removeMessageHandler(id, this);
+            }
+        }
+
+        val id = BufferList.addOneOffMessageHandler(handler)
+        Events.SendMessageEvent.fire("($id) $message")
+    }
+}


### PR DESCRIPTION
Fixes #446 

Add a new Event based on SendMessageEvent which when fired returns a CompletableFuture which resolves with the associated response; use that to implement >= 2.9 completion via the relay; fallback to the previous strategy if completion fails.