### PR TITLE
Display day change messages

### DIFF
--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Buffer.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Buffer.kt
@@ -25,6 +25,7 @@ class Buffer @WorkerThread constructor(
     @JvmField var shortName: String = ""
     @JvmField var hidden: Boolean = false
     @JvmField var type = BufferSpec.Type.Other
+    @JvmField var displayDayChange: Boolean = false
 
     private var notify: Notify = Notify.default
 
@@ -34,6 +35,7 @@ class Buffer @WorkerThread constructor(
         internal var updateHidden = false
         internal var updateType = false
         internal var updateNotifyLevel = false
+        internal var updateDayChange = false
 
         var number: Int by updatable(::updateName, this@Buffer::number)
         var fullName: String by updatable(::updateName, this@Buffer::fullName)
@@ -42,6 +44,7 @@ class Buffer @WorkerThread constructor(
         var hidden: Boolean by updatable(::updateHidden)
         var type: BufferSpec.Type by updatable(::updateType)
         var notify: Notify? by updatable(::updateNotifyLevel)
+        var displayDayChange: Boolean by updatable(::updateDayChange)
     }
 
     fun update(block: Updater.() -> Unit) {
@@ -65,6 +68,7 @@ class Buffer @WorkerThread constructor(
         if (updater.updateNotifyLevel) notify = updater.notify ?: Notify.default
         if (updater.updateHidden) hidden = updater.hidden
         if (updater.updateType) type = updater.type
+        if (updater.updateDayChange) displayDayChange = updater.displayDayChange
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -215,7 +219,7 @@ class Buffer @WorkerThread constructor(
         }
 
         synchronized(this) {
-            lines.replaceLines(newLines)
+            lines.replaceLines(newLines, displayDayChange)
         }
    }
 
@@ -227,7 +231,7 @@ class Buffer @WorkerThread constructor(
         val notifyPmOrMessage = line.notifyLevel == LineSpec.NotifyLevel.Message || notifyPm
 
         synchronized(this) {
-            lines.addLast(line)
+            lines.addLast(line, displayDayChange)
 
             // notify levels: 0 none 1 highlight 2 message 3 all
             // treat hidden lines and lines that are not supposed to generate a “notification” as read

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Lines.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Lines.kt
@@ -121,7 +121,12 @@ class Lines {
         }
         msg += " --"
 
-        return Line(++fakePointerCounter, LineSpec.Type.Other, tstamp, "--", msg,
+        var datePointer = MAX_C_POINTER_VALUE shl 2 + newDate.getYear() shl 32
+                          + newDate.getDayOfYear() shl 20
+        if (oldDate != null) {
+            datePointer += oldDate.getYear() shl 16 + oldDate.getDayOfYear()
+        }
+        return Line(datePointer, LineSpec.Type.Other, tstamp, "--", msg,
                     nick = null, isVisible = true, isHighlighted = false,
                     LineSpec.DisplayAs.Unspecified, LineSpec.NotifyLevel.Low)
     }

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Lines.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Lines.kt
@@ -91,9 +91,8 @@ class Lines {
         if (status != Status.Fetching) return
         unfiltered.clear()
         filtered.clear()
-        unfiltered.addAll(lines)
         for (line in lines) {
-            if (line.isVisible) filtered.add(line)
+            addLast(line)
         }
     }
 

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Spec.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Spec.kt
@@ -39,6 +39,7 @@ enum class Notify(val value: Int) {
     inline val notify: Notify? get() = Notify::value.find(entry.getIntOrNull("notify"))
     inline val type get() = Type.fromLocalVariables(entry.getHashtable("local_variables"))
     inline val hidden get() = entry.getIntOrNull("hidden") == 1
+    inline val displayDayChange get() = entry.getIntOrNull("day_change") == 1
 
     // todo get rid of openWhileRunning
     fun toBuffer(openWhileRunning: Boolean) = Buffer(pointer).apply {
@@ -50,6 +51,7 @@ enum class Notify(val value: Int) {
             notify = this@BufferSpec.notify
             hidden = this@BufferSpec.hidden
             type = this@BufferSpec.type
+            displayDayChange = this@BufferSpec.displayDayChange
         }
 
         if (P.isBufferOpen(pointer)) setOpen(open = true, syncHotlistOnOpen = false)
@@ -67,7 +69,7 @@ enum class Notify(val value: Int) {
 
     companion object {
         const val listBuffersRequest = "(listbuffers) hdata buffer:gui_buffers(*) " +
-                "number,full_name,short_name,type,title,nicklist,local_variables,notify,hidden"
+                "number,full_name,short_name,type,title,nicklist,local_variables,notify,hidden,day_change"
 
         const val renumberRequest = "(renumber) hdata buffer:gui_buffers(*) number"
     }


### PR DESCRIPTION
The WA FAQ proposes to do this via trigger:

https://github.com/ubergeek42/weechat-android/wiki/FAQ#i-dont-see-date-change-messages

But this does not work for other buffers and produces log messages.