### PR TITLE
Fix emoji rendering on Android 11 and older

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -25,7 +25,8 @@ dependencies {
     implementation("androidx.core:core-ktx:1.6.0-rc01")
     implementation("androidx.legacy:legacy-support-v4:1.0.0")
     implementation("androidx.annotation:annotation:1.2.0") // For @Nullable/@NonNull
-    implementation("androidx.appcompat:appcompat:1.3.0")
+    implementation("androidx.appcompat:appcompat:1.4.1")
+    implementation("androidx.emoji2:emoji2:1.0.1")
     implementation("androidx.preference:preference-ktx:1.1.1")  // preference fragment & al
     implementation("androidx.legacy:legacy-preference-v14:1.0.0") // styling for the fragment
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -30,7 +30,7 @@ dependencies {
     implementation("androidx.legacy:legacy-preference-v14:1.0.0") // styling for the fragment
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.3.1")
     implementation("androidx.lifecycle:lifecycle-common-java8:2.3.1")
-    implementation("androidx.sharetarget:sharetarget:1.1.0")
+    implementation("androidx.sharetarget:sharetarget:1.2.0-rc01")
 
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0")
 
@@ -67,14 +67,14 @@ tasks.withType<JavaCompile> {
 }
 
 android {
-    compileSdkVersion(30)
+    compileSdkVersion(31)
 
     defaultConfig {
         versionCode = 1_07_01
         versionName = "1.7.1"
 
         minSdkVersion(21)
-        targetSdkVersion(30)
+        targetSdkVersion(31)
         buildConfigField("String", "VERSION_BANNER", "\"" + versionBanner() + "\"")
 
         vectorDrawables.useSupportLibrary = true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,8 @@
         <activity
             android:name=".WeechatActivity"
             android:launchMode="singleTask"
-            android:windowSoftInputMode="stateHidden">
+            android:windowSoftInputMode="stateHidden"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -69,7 +70,8 @@
         <!-- text only -->
         <activity-alias
             android:targetActivity=".ShareTextActivity"
-            android:name=".ShareActivityText">
+            android:name=".ShareActivityText"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -84,7 +86,8 @@
         <!-- text, images and videos -->
         <activity-alias
             android:targetActivity=".ShareTextActivity"
-            android:name=".ShareActivityMedia">
+            android:name=".ShareActivityMedia"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -119,7 +122,8 @@
         <!-- everything -->
         <activity-alias
             android:targetActivity=".ShareTextActivity"
-            android:name=".ShareActivityEverything">
+            android:name=".ShareActivityEverything"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -138,14 +142,16 @@
 
 
         <activity android:name=".PreferencesActivity" />
-        <activity android:name=".WeechatAboutActivity">
+        <activity android:name=".WeechatAboutActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW"/>
                 <category android:name="android.intent.category.DEFAULT" />
             </intent-filter>
         </activity>
         <receiver android:enabled="true" android:name=".service.BootUpReceiver"
-            android:permission="android.permission.RECEIVE_BOOT_COMPLETED">
+            android:permission="android.permission.RECEIVE_BOOT_COMPLETED"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
     <uses-permission android:name="${applicationId}.permission.PING_ACTION"/>
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
 
     <!--
         this can be used to create persistent dialogs for rare errors for debug purposes

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/notifications/Notificator.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/notifications/Notificator.kt
@@ -99,7 +99,7 @@ private val connectionStatusTapPendingIntent = PendingIntent.getActivity(
     applicationContext,
     0,
     Intent(applicationContext, WeechatActivity::class.java),
-    PendingIntent.FLAG_CANCEL_CURRENT
+    PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_MUTABLE
 )
 
 
@@ -107,7 +107,7 @@ private val disconnectActionPendingIntent = PendingIntent.getService(
     applicationContext,
     0,
     Intent(RelayService.ACTION_STOP, null, applicationContext, RelayService::class.java),
-    0
+    PendingIntent.FLAG_MUTABLE
 )
 
 
@@ -153,13 +153,15 @@ private inline fun <reified T : Activity> makeActivityIntent(pointer: Long): Pen
         putExtra(Constants.EXTRA_BUFFER_POINTER, pointer)
         action = pointer.as0x
     }
-    return PendingIntent.getActivity(applicationContext, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+    return PendingIntent.getActivity(applicationContext, 0, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE)
 }
 
 
 private inline fun <reified T : BroadcastReceiver> makeBroadcastIntent(pointer: Long): PendingIntent {
     val intent = Intent(applicationContext, T::class.java).apply { action = pointer.as0x }
-    return PendingIntent.getBroadcast(applicationContext, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+    return PendingIntent.getBroadcast(applicationContext, 0, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE)
 }
 
 
@@ -568,7 +570,7 @@ private fun makeActionForBufferPointer(pointer: Long): NotificationCompat.Action
         applicationContext,
         1,
         Intent(applicationContext, InlineReplyReceiver::class.java).apply { action = pointer.as0x },
-        PendingIntent.FLAG_UPDATE_CURRENT
+        PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
     )
 
     return NotificationCompat.Action.Builder(

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/service/PingActionReceiver.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/service/PingActionReceiver.java
@@ -89,7 +89,8 @@ public class PingActionReceiver extends BroadcastReceiver {
     @AnyThread public void unschedulePing() {
         if (!P.pingEnabled) return;
         Intent intent = new Intent(PING_ACTION);
-        PendingIntent pi = PendingIntent.getBroadcast(bone, 0, intent, PendingIntent.FLAG_NO_CREATE);
+        PendingIntent pi = PendingIntent.getBroadcast(bone, 0, intent,
+                PendingIntent.FLAG_NO_CREATE | PendingIntent.FLAG_MUTABLE);
         if (pi != null) alarmManager.cancel(pi);
         try {
             bone.unregisterReceiver(this);
@@ -111,7 +112,8 @@ public class PingActionReceiver extends BroadcastReceiver {
     @AnyThread private void schedulePing(long triggerAt, @NonNull Bundle extras) {
         Intent intent = new Intent(PING_ACTION);
         intent.putExtras(extras);
-        PendingIntent alarmIntent = PendingIntent.getBroadcast(bone, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+        PendingIntent alarmIntent = PendingIntent.getBroadcast(bone, 0, intent,
+                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             alarmManager.setExact(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerAt, alarmIntent);

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/service/SyncAlarmReceiver.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/service/SyncAlarmReceiver.java
@@ -20,13 +20,15 @@ public class SyncAlarmReceiver extends BroadcastReceiver {
         AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
         if (am == null) return;
         Intent intent = new Intent(context, SyncAlarmReceiver.class);
-        PendingIntent pi = PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+        PendingIntent pi = PendingIntent.getBroadcast(context, 0, intent,
+                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_MUTABLE);
         am.setInexactRepeating(AlarmManager.ELAPSED_REALTIME_WAKEUP, SystemClock.elapsedRealtime() + SYNC_EVERY_MS, SYNC_EVERY_MS, pi);
     }
 
     @AnyThread public static void stop(Context context) {
         AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-        PendingIntent pe = PendingIntent.getBroadcast(context, 0, new Intent(context, SyncAlarmReceiver.class), 0);
+        PendingIntent pe = PendingIntent.getBroadcast(context, 0, new Intent(context, SyncAlarmReceiver.class),
+                PendingIntent.FLAG_MUTABLE);
         if (am != null && pe != null) am.cancel(pe);
     }
 

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/views/AlphaLayout.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/views/AlphaLayout.kt
@@ -8,6 +8,7 @@ import android.os.Build
 import android.text.Layout
 import android.text.Spannable
 import android.text.StaticLayout
+import androidx.emoji2.text.EmojiCompat
 import com.ubergeek42.WeechatAndroid.service.P
 import com.ubergeek42.WeechatAndroid.upload.f
 import com.ubergeek42.WeechatAndroid.upload.i
@@ -34,7 +35,7 @@ internal class AlphaLayout private constructor(
     fun usesCurrentPaint() = layout.paint === P.textPaint
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
-    
+
     val paint: Paint get() = layout.paint
     val height: Int get() = layout.height
     fun draw(canvas: Canvas) = layout.draw(canvas)
@@ -56,14 +57,15 @@ internal class AlphaLayout private constructor(
         @Suppress("DEPRECATION")
         @JvmStatic
         fun make(spannable: Spannable, anyWidth: Int): AlphaLayout {
+            val text = EmojiCompat.get().process(spannable) ?: spannable
             val width = if (anyWidth > 0) anyWidth else 100
             val layout = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                StaticLayout.Builder.obtain(spannable, 0, spannable.length, P.textPaint, width)
+                StaticLayout.Builder.obtain(text, 0, text.length, P.textPaint, width)
                         .setBreakStrategy(Layout.BREAK_STRATEGY_HIGH_QUALITY)
                         .setHyphenationFrequency(Layout.HYPHENATION_FREQUENCY_NORMAL)
                         .build()
             } else {
-                StaticLayout(spannable, P.textPaint, width,
+                StaticLayout(text, P.textPaint, width,
                         ALIGNMENT, SPACING_MULTIPLIER, SPACING_ADDITION, INCLUDE_PADDING)
             }
             return AlphaLayout(layout)

--- a/cats/build.gradle.kts
+++ b/cats/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
 }
 
 android {
-    compileSdkVersion(30)
+    compileSdkVersion(31)
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
@@ -34,7 +34,7 @@ android {
     }
 
     defaultConfig {
-        targetSdkVersion(30)
+        targetSdkVersion(31)
         minSdkVersion(16)
     }
 }


### PR DESCRIPTION
Fixes #535, see there for context. For the most part, upgrading `appcompat` to 1.4 was sufficient, except for the main chat view where using `EmojiCompat` directly was necessary, as described [here](https://developer.android.com/guide/topics/ui/look-and-feel/emoji2#no-widgets).

<details>
<summary>Screenshot</summary>

![screenshot](https://f.monade.li/DD3I9q.jpg)
</details>