### PR TITLE
Keep relay buffer when clicking on the nicklist

### DIFF
--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/dialogs/NicklistDialog.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/dialogs/NicklistDialog.kt
@@ -34,7 +34,7 @@ class NicklistDialog : ListDialog(),
             this.buffer = buffer
             this.title = buffer.shortName
             this.adapter = NicklistAdapter(requireContext()) {
-                Events.SendMessageEvent.fire("input 0x%x /query %s", buffer.pointer, it.name)
+                Events.SendMessageEvent.fire("input 0x%x /query -noswitch %s", buffer.pointer, it.name)
                 dismiss()
             }
         }


### PR DESCRIPTION
When clicking on a nick on the nicklist, the `/query` command is issued, causing the relay to switch its buffer to the query.  weechat-android should switch the *client* buffer instead (see #538), but leave the relay buffer intact.
If the relay buffer is switched, it may cause missed notifications due to weechat  incorrectly believing that messages have been seen on the relay, since the buffer is opened.

Fixes #550