### PR TITLE
Implement roles for volume buttons: do nothing, change text size, navigate sent history

### DIFF
--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
@@ -123,7 +123,10 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
     public static boolean notificationVibrate;
     public static String notificationSound;
 
-    public static boolean showSend, showTab, showPaperclip, hotlistSync, volumeBtnSize;
+    public static boolean showSend, showTab, showPaperclip, hotlistSync;
+
+    public enum VolumeRole {NONE, TEXT_SIZE, SEND_HISTORY};
+    public static VolumeRole volumeRole;
 
     public static boolean showBufferFilter;
 
@@ -167,7 +170,7 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
         showTab = p.getBoolean(PREF_SHOW_TAB, PREF_SHOW_TAB_D);
         showPaperclip = p.getBoolean(PREF_SHOW_PAPERCLIP, PREF_SHOW_PAPERCLIP_D);
         hotlistSync = p.getBoolean(PREF_HOTLIST_SYNC, PREF_HOTLIST_SYNC_D);
-        volumeBtnSize = p.getBoolean(PREF_VOLUME_BTN_SIZE, PREF_VOLUME_BTN_SIZE_D);
+        volumeRole = VolumeRole.values()[Integer.parseInt(p.getString(PREF_VOLUME_ROLE, PREF_VOLUME_ROLE_D))];
 
         // buffer list filter
         showBufferFilter = p.getBoolean(PREF_SHOW_BUFFER_FILTER, PREF_SHOW_BUFFER_FILTER_D);
@@ -365,7 +368,7 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
             case PREF_SHOW_TAB: showTab = p.getBoolean(key, PREF_SHOW_TAB_D); break;
             case PREF_SHOW_PAPERCLIP: showPaperclip = p.getBoolean(key, PREF_SHOW_PAPERCLIP_D); break;
             case PREF_HOTLIST_SYNC: hotlistSync = p.getBoolean(key, PREF_HOTLIST_SYNC_D); break;
-            case PREF_VOLUME_BTN_SIZE: volumeBtnSize = p.getBoolean(key, PREF_VOLUME_BTN_SIZE_D); break;
+            case PREF_VOLUME_ROLE: volumeRole = VolumeRole.values()[Integer.parseInt(p.getString(PREF_VOLUME_ROLE, PREF_VOLUME_ROLE_D))]; break;
 
             // buffer list fragment
             case PREF_SHOW_BUFFER_FILTER: showBufferFilter = p.getBoolean(key, PREF_SHOW_BUFFER_FILTER_D); break;

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/Constants.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/Constants.java
@@ -4,6 +4,7 @@ import android.os.Build;
 
 import com.ubergeek42.WeechatAndroid.R;
 import com.ubergeek42.WeechatAndroid.Weechat;
+import com.ubergeek42.WeechatAndroid.service.P;
 
 import java.util.Set;
 
@@ -123,8 +124,8 @@ public class Constants {
     final public static boolean PREF_SHOW_SEND_D = true;
     public final static String PREF_SHOW_TAB = "tabbtn_show";
     final public static boolean PREF_SHOW_TAB_D = true;
-    public final static String PREF_VOLUME_BTN_SIZE = "volumebtn_size";
-    final public static boolean PREF_VOLUME_BTN_SIZE_D = true;
+    public final static String PREF_VOLUME_ROLE = "buttons__volume";
+    final public static String PREF_VOLUME_ROLE_D = String.valueOf(P.VolumeRole.TEXT_SIZE.ordinal());
 
     final public static String PREF_SHOW_PAPERCLIP = "buttons__show_paperclip";
     final public static boolean PREF_SHOW_PAPERCLIP_D = true;
@@ -256,5 +257,6 @@ public class Constants {
         final static public String PREF_SSH_KEY = "ssh_key"; final public static String PREF_SSH_KEY_D = null;
         final static public String PREF_SSH_KEY_PASSPHRASE = "ssh_key_passphrase"; final public static String PREF_SSH_KEY_PASSPHRASE_D = null;
         final static public String PREF_SSH_KNOWN_HOSTS = "ssh_known_hosts"; final public static String PREF_SSH_KNOWN_HOSTS_D = "";
+        final static public String PREF_VOLUME_BTN_SIZE = "volumebtn_size"; final public static boolean PREF_VOLUME_BTN_SIZE_D = true;
     }
 }

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/History.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/History.kt
@@ -1,0 +1,54 @@
+package com.ubergeek42.WeechatAndroid.utils
+
+import android.os.Bundle
+import android.text.Editable
+import android.widget.EditText
+import androidx.core.os.bundleOf
+import com.ubergeek42.WeechatAndroid.service.P
+
+class History {
+    private var index = -1
+    private var userInput: Editable? = null
+    private var selectionStart: Int? = null
+    private var selectionEnd: Int? = null
+
+    fun navigateOffset(editText: EditText, offset: Int) {
+        if (index == -1) {
+            userInput = editText.text
+            selectionStart = editText.selectionStart
+            selectionEnd = editText.selectionEnd
+        }
+        val newIndex = index + offset
+        messageAt(newIndex)?.let {
+            editText.text = it
+            editText.post {
+                if (newIndex == -1) {
+                    // Restore user selection.
+                    editText.setSelection(selectionStart ?: 0, selectionEnd ?: editText.length())
+                } else {
+                    // Go to end for sent messages.
+                    editText.setSelection(editText.length())
+                }
+            }
+            index = newIndex
+        }
+    }
+
+    fun save(): Bundle = bundleOf(
+        Pair("index", index),
+        Pair("userInput", userInput),
+        Pair("selStart", selectionStart),
+        Pair("selEnd", selectionEnd),
+    )
+
+    fun restore(bundle: Bundle) {
+        index = bundle.getInt("index", -1)
+        userInput = bundle.get("userInput") as Editable?
+        selectionStart = bundle.getInt("selStart", -1).let { if (it == -1) null else it }
+        selectionEnd = bundle.getInt("selEnd", -1).let { if (it == -1) null else it }
+    }
+
+    private fun messageAt(index: Int): Editable? =
+        if (index == -1) userInput else P.sentMessages.getOrNull(P.sentMessages.size - 1 - index)
+            ?.let { Editable.Factory.getInstance().newEditable(it) }
+}

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/MigratePreferences.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/MigratePreferences.kt
@@ -1,14 +1,15 @@
 package com.ubergeek42.WeechatAndroid.utils
 
 import android.content.Context
+import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import androidx.preference.PrivateKeyPickerPreference
+import com.ubergeek42.WeechatAndroid.service.P.VolumeRole
 import com.ubergeek42.WeechatAndroid.upload.applicationContext
 import com.ubergeek42.WeechatAndroid.utils.AndroidKeyStoreUtils.InsideSecurityHardware
 import com.ubergeek42.cats.Kitty
 import com.ubergeek42.cats.Root
 import com.ubergeek42.weechat.relay.connection.SSHConnection
-import java.util.*
 
 
 class MigratePreferences(val context: Context) {
@@ -175,6 +176,14 @@ class MigratePreferences(val context: Context) {
                 showInfo("The app no longer requests external storage permission. " +
                          "If you are using custom fonts or themes, " +
                          "you may have to import them in settings.")
+            }
+        }
+
+        add(5, 6) {
+            val volumeChangesSize = preferences.getBoolean(Constants.Deprecated.PREF_VOLUME_BTN_SIZE, Constants.Deprecated.PREF_VOLUME_BTN_SIZE_D)
+            preferences.edit {
+                this.remove(Constants.Deprecated.PREF_VOLUME_BTN_SIZE)
+                this.putString(Constants.PREF_VOLUME_ROLE, (if (volumeChangesSize) VolumeRole.TEXT_SIZE else VolumeRole.NONE).ordinal.toString(10))
             }
         }
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -703,11 +703,9 @@
         wenn der Büroklammer-Taste versteckt wurde,
         um mehr Platz für das Eingabefeld zu schaffen.</string>
 
-    <string name="pref__buttons__volume_buttons_change_text_size">
-        Lautstärketasten ändern die Textgröße</string>
-    <string name="pref__buttons__volume_buttons_change_text_size_summary">
-        Wenn diese Option aktiviert ist,
-        ändern die Lautstärketasten die Textgröße, anstelle der Lautstärke</string>
+    <string name="pref_buttons_volume__actions__none">Nichts tun</string>
+    <string name="pref_buttons_volume__actions__text_size">Lautstärketasten ändern die Textgröße</string>
+    <string name="pref_buttons_volume__actions__history">Navigieren im Sendeverlauf</string>
 
     <!-- ####################################################################################### -->
     <!-- #################################### notifications #################################### -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -691,12 +691,9 @@
         Quand le bouton «&#8239;trombone&#8239;» devient invisible pour laisser de la place au champ de saisie,
         il reste possible de joindre des fichiers via le menu déroulant.</string>
 
-    <string name="pref__buttons__volume_buttons_change_text_size">
-        Taille du texte via le volume</string>
-    <string name="pref__buttons__volume_buttons_change_text_size_summary">
-        Si coché, les boutons du volume audio changent la taille du texte
-        lorsque Weechat-Android est au premier plan</string>
-
+    <string name="pref_buttons_volume__actions__none">Ne rien faire</string>
+    <string name="pref_buttons_volume__actions__text_size">Changer la taille du texte</string>
+    <string name="pref_buttons_volume__actions__history">Naviguer dans les messages envoyés</string>
     <!-- ####################################################################################### -->
     <!-- #################################### notifications #################################### -->
     <!-- ####################################################################################### -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -699,10 +699,9 @@
         Когда кнопка «Скрепка» скрыта, чтобы оставить больше места для поля ввода,
         выбирать файлы можно через меню.</string>
 
-    <string name="pref__buttons__volume_buttons_change_text_size">
-        Кнопки громкости меняют размер текста</string>
-    <string name="pref__buttons__volume_buttons_change_text_size_summary">
-        Если настройка включена, кнопки громкости будут менять размер текста вместо громкости</string>
+    <string name="pref_buttons_volume__actions__none">Ничего не делать</string>
+    <string name="pref_buttons_volume__actions__text_size">Кнопки громкости меняют размер текста</string>
+    <string name="pref_buttons_volume__actions__history">Навигация по истории отправлений</string>
 
     <!-- ####################################################################################### -->
     <!-- #################################### notifications #################################### -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -714,10 +714,16 @@
         When the paperclip button gets hidden to provide more space for the input field,
         you can still attach files via overflow menu.</string>
 
-    <string name="pref__buttons__volume_buttons_change_text_size">
-        Volume buttons change text size</string>
-    <string name="pref__buttons__volume_buttons_change_text_size_summary">
-        If set, volume buttons will change text size instead of volume</string>
+    <string name="pref__buttons__volume__title">Volume button role</string>
+    <string-array name="pref__buttons__volume__entries">
+        <item>@string/pref_buttons_volume__actions__none</item>
+        <item>@string/pref_buttons_volume__actions__text_size</item>
+        <item>@string/pref_buttons_volume__actions__history</item>
+    </string-array>
+
+    <string name="pref_buttons_volume__actions__none">Do nothing</string>
+    <string name="pref_buttons_volume__actions__text_size">Change text size</string>
+    <string name="pref_buttons_volume__actions__history">Navigate sent history</string>
 
     <!-- ####################################################################################### -->
     <!-- #################################### notifications #################################### -->

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -78,6 +78,12 @@
         <item>4</item>
     </string-array>
 
+    <string-array name="pref__buttons__volume__values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+    </string-array>
+
     <string-array name="pref__buttons__paperclip__action_1_values">
         <item>content_images</item>
         <item>content_media</item>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -350,11 +350,13 @@
             android:persistent="false"
             android:selectable="false"
             android:dependency="buttons__show_paperclip" />
-        <CheckBoxPreference
-            android:key="volumebtn_size"
-            android:title="@string/pref__buttons__volume_buttons_change_text_size"
-            android:summary="@string/pref__buttons__volume_buttons_change_text_size_summary"
-            android:defaultValue="true" />
+        <ListPreference
+            android:key="buttons__volume"
+            android:title="@string/pref__buttons__volume__title"
+            android:entries="@array/pref__buttons__volume__entries"
+            android:entryValues="@array/pref__buttons__volume__values"
+            android:defaultValue="1"
+            app:useSimpleSummaryProvider="true" />
     </PreferenceScreen>
 
     <!-- notifications -->


### PR DESCRIPTION
The navigation state is saved and restored along with BufferFragment's lifecycle.
The deprecated preference is migrated to the correspondig volume role.

Supersedes #297. Fixes #553.