### PR TITLE
Volume buttons: implement Weechat-like input history rather than sent history

### DIFF
--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.kt
@@ -148,7 +148,6 @@ class BufferFragment : Fragment(), BufferEye {
         savedInstanceState?.let {
             restoreRecyclerViewState(it)
             restoreSearchState(it)
-            restoreHistoryState(it)
         }
     }
 
@@ -281,7 +280,6 @@ class BufferFragment : Fragment(), BufferEye {
         super.onSaveInstanceState(outState)
         saveRecyclerViewState(outState)
         saveSearchState(outState)
-        saveHistoryState(outState)
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -518,15 +516,15 @@ class BufferFragment : Fragment(), BufferEye {
             KeyEvent.KEYCODE_VOLUME_DOWN, KeyEvent.KEYCODE_VOLUME_UP -> {
                 val up = keyCode == KeyEvent.KEYCODE_VOLUME_UP
                 when (P.volumeRole) {
-                    P.VolumeRole.TEXT_SIZE -> {
+                    P.VolumeRole.ChangeTextSize -> {
                         val change = if (up) 1f else -1f
                         val textSize = (P.textSize + change).coerceIn(5f, 30f)
                         P.setTextSizeColorAndLetterWidth(textSize)
                         return@OnKeyListener true
                     }
-                    P.VolumeRole.SEND_HISTORY -> {
-                        ulet(ui?.chatInput) {
-                            history.navigateOffset(it, if (up) 1 else -1)
+                    P.VolumeRole.NavigateInputHistory -> {
+                        ui?.chatInput?.let {
+                            P.history.navigate(it, if (up) History.Direction.Older else History.Direction.Newer)
                         }
                         return@OnKeyListener true
                     }
@@ -550,6 +548,7 @@ class BufferFragment : Fragment(), BufferEye {
             assertThat(buffer).isEqualTo(linesAdapter?.buffer)
             if (connectedToRelayAndSynced) {
                 SendMessageEvent.fireInput(buffer, input.text.toString())
+                P.history.reset(input)
                 input.setText("")   // this will reset tab completion
             } else {
                 Toaster.ErrorToast.show(R.string.error__etc__not_connected)
@@ -954,20 +953,6 @@ class BufferFragment : Fragment(), BufferEye {
                 }
             }
         }
-    }
-
-    ////////////////////////////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////////////////// history
-    ////////////////////////////////////////////////////////////////////////////////////////////////
-
-    private val history = History()
-
-    private fun saveHistoryState(outState: Bundle) {
-        outState.putBundle(KEY_HISTORY, history.save())
-    }
-
-    private fun restoreHistoryState(savedInstanceState: Bundle) {
-        savedInstanceState.getBundle(KEY_HISTORY)?.let { history.restore(it) }
     }
 
     ////////////////////////////////////////////////////////////////////////////////////////////////

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/Constants.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/Constants.java
@@ -125,7 +125,7 @@ public class Constants {
     public final static String PREF_SHOW_TAB = "tabbtn_show";
     final public static boolean PREF_SHOW_TAB_D = true;
     public final static String PREF_VOLUME_ROLE = "buttons__volume";
-    final public static String PREF_VOLUME_ROLE_D = String.valueOf(P.VolumeRole.TEXT_SIZE.ordinal());
+    final public static String PREF_VOLUME_ROLE_D = P.VolumeRole.ChangeTextSize.value;
 
     final public static String PREF_SHOW_PAPERCLIP = "buttons__show_paperclip";
     final public static boolean PREF_SHOW_PAPERCLIP_D = true;

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/MigratePreferences.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/MigratePreferences.kt
@@ -183,7 +183,10 @@ class MigratePreferences(val context: Context) {
             val volumeChangesSize = preferences.getBoolean(Constants.Deprecated.PREF_VOLUME_BTN_SIZE, Constants.Deprecated.PREF_VOLUME_BTN_SIZE_D)
             preferences.edit {
                 this.remove(Constants.Deprecated.PREF_VOLUME_BTN_SIZE)
-                this.putString(Constants.PREF_VOLUME_ROLE, (if (volumeChangesSize) VolumeRole.TEXT_SIZE else VolumeRole.NONE).ordinal.toString(10))
+                this.putString(
+                    Constants.PREF_VOLUME_ROLE,
+                    (if (volumeChangesSize) VolumeRole.ChangeTextSize else VolumeRole.DoNothing).value
+                )
             }
         }
     }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -703,9 +703,10 @@
         wenn der Büroklammer-Taste versteckt wurde,
         um mehr Platz für das Eingabefeld zu schaffen.</string>
 
-    <string name="pref_buttons_volume__actions__none">Nichts tun</string>
-    <string name="pref_buttons_volume__actions__text_size">Lautstärketasten ändern die Textgröße</string>
-    <string name="pref_buttons_volume__actions__history">Navigieren im Sendeverlauf</string>
+    <string name="pref__buttons__volume__title">Lautstärketasten</string>
+    <string name="pref__buttons__volume__actions__none">Nichts tun</string>
+    <string name="pref__buttons__volume__actions__change_text_size">Lautstärketasten ändern die Textgröße</string>
+    <string name="pref__buttons__volume__actions__navigate_input_history">Navigieren Sie durch den Eingabeverlauf</string>
 
     <!-- ####################################################################################### -->
     <!-- #################################### notifications #################################### -->

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -32,6 +32,12 @@
     <string name="error__etc__cannot_share_to_empty_buffer_list">Aucun tampon disponible pour partager</string>
     <string name="error__etc__activity_not_found_for_url">Activité introuvable pour “l’intent” %s</string>
 
+    <plurals name="error__history_with_sharespans">
+        <item quantity="one" tools:ignore="ImpliedQuantity">Supprimez ou uploadez l’image pour naviguer</item>
+        <item quantity="other">Supprimez ou uploadez les images pour naviguer</item>
+        <item quantity="many">Supprimez ou uploadez les images pour naviguer</item>
+    </plurals>
+
     <!-- ############################## main activity ui elements ############################## -->
 
     <string name="ui__button_paperclip">Téléverser un fichier</string>
@@ -691,9 +697,11 @@
         Quand le bouton «&#8239;trombone&#8239;» devient invisible pour laisser de la place au champ de saisie,
         il reste possible de joindre des fichiers via le menu déroulant.</string>
 
-    <string name="pref_buttons_volume__actions__none">Ne rien faire</string>
-    <string name="pref_buttons_volume__actions__text_size">Changer la taille du texte</string>
-    <string name="pref_buttons_volume__actions__history">Naviguer dans les messages envoyés</string>
+    <string name="pref__buttons__volume__title">Les boutons de volume</string>
+    <string name="pref__buttons__volume__actions__none">Ne font rien de spécial</string>
+    <string name="pref__buttons__volume__actions__change_text_size">Changent la taille du texte</string>
+    <string name="pref__buttons__volume__actions__navigate_input_history">Naviguent dans l’historique de saisie</string>
+
     <!-- ####################################################################################### -->
     <!-- #################################### notifications #################################### -->
     <!-- ####################################################################################### -->

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -699,9 +699,10 @@
         Когда кнопка «Скрепка» скрыта, чтобы оставить больше места для поля ввода,
         выбирать файлы можно через меню.</string>
 
-    <string name="pref_buttons_volume__actions__none">Ничего не делать</string>
-    <string name="pref_buttons_volume__actions__text_size">Кнопки громкости меняют размер текста</string>
-    <string name="pref_buttons_volume__actions__history">Навигация по истории отправлений</string>
+    <string name="pref__buttons__volume__title">Кнопки громкости</string>
+    <string name="pref__buttons__volume__actions__none">Ничего не делать</string>
+    <string name="pref__buttons__volume__actions__change_text_size">Кнопки громкости меняют размер текста</string>
+    <string name="pref__buttons__volume__actions__navigate_input_history">Навигация по истории ввода</string>
 
     <!-- ####################################################################################### -->
     <!-- #################################### notifications #################################### -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -35,6 +35,11 @@
     <string name="error__etc__cannot_share_to_empty_buffer_list">Buffer list empty</string>
     <string name="error__etc__activity_not_found_for_url">Activity not found for intent %s</string>
 
+    <plurals name="error__history_with_sharespans">
+        <item quantity="one">Remove or upload the image to navigate</item>
+        <item quantity="other">Remove or upload the images to navigate</item>
+    </plurals>
+
     <!-- ############################## main activity ui elements ############################## -->
 
     <string name="ui__button_paperclip">Upload file</string>
@@ -714,16 +719,16 @@
         When the paperclip button gets hidden to provide more space for the input field,
         you can still attach files via overflow menu.</string>
 
-    <string name="pref__buttons__volume__title">Volume button role</string>
+    <string name="pref__buttons__volume__title">Volume buttons</string>
     <string-array name="pref__buttons__volume__entries">
-        <item>@string/pref_buttons_volume__actions__none</item>
-        <item>@string/pref_buttons_volume__actions__text_size</item>
-        <item>@string/pref_buttons_volume__actions__history</item>
+        <item>@string/pref__buttons__volume__actions__none</item>
+        <item>@string/pref__buttons__volume__actions__change_text_size</item>
+        <item>@string/pref__buttons__volume__actions__navigate_input_history</item>
     </string-array>
 
-    <string name="pref_buttons_volume__actions__none">Do nothing</string>
-    <string name="pref_buttons_volume__actions__text_size">Change text size</string>
-    <string name="pref_buttons_volume__actions__history">Navigate sent history</string>
+    <string name="pref__buttons__volume__actions__none">No special action</string>
+    <string name="pref__buttons__volume__actions__change_text_size">Change text size</string>
+    <string name="pref__buttons__volume__actions__navigate_input_history">Navigate input history</string>
 
     <!-- ####################################################################################### -->
     <!-- #################################### notifications #################################### -->

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -79,9 +79,9 @@
     </string-array>
 
     <string-array name="pref__buttons__volume__values">
-        <item>0</item>
-        <item>1</item>
-        <item>2</item>
+        <item>none</item>
+        <item>change_text_size</item>
+        <item>navigate_input_history</item>
     </string-array>
 
     <string-array name="pref__buttons__paperclip__action_1_values">

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -355,7 +355,7 @@
             android:title="@string/pref__buttons__volume__title"
             android:entries="@array/pref__buttons__volume__entries"
             android:entryValues="@array/pref__buttons__volume__values"
-            android:defaultValue="1"
+            android:defaultValue="change_text_size"
             app:useSimpleSummaryProvider="true" />
     </PreferenceScreen>
 


### PR DESCRIPTION
Please see #554 comments.

* Similar behavior to Weechat native input
* Don't store whitespace-only messages
* Prevent navigation if user has non-uploaded ShareSpans, and display an error toast