### PR TITLE
Allow drag n drop & fix a few issues with file sharing

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     implementation(project(":cats"))
     implementation(project(":relay"))
 
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.0")
+    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.20")
 
     // these two are required for logging within the relay module. todo remove?
     implementation("org.slf4j:slf4j-api:1.7.36")
@@ -87,9 +87,6 @@ android {
         }
 
         kotlinOptions {
-            freeCompilerArgs = listOf(
-                    "-language-version", "1.7",
-                    "-api-version", "1.7")
             jvmTarget = "11"
         }
     }

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/fragments/BufferFragment.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.os.Bundle
 import android.transition.Fade
 import android.transition.TransitionManager
+import android.view.DragEvent
 import android.view.KeyEvent
 import android.view.LayoutInflater
 import android.view.Menu
@@ -54,9 +55,11 @@ import com.ubergeek42.WeechatAndroid.upload.MediaAcceptingEditText.HasLayoutList
 import com.ubergeek42.WeechatAndroid.upload.ShareObject
 import com.ubergeek42.WeechatAndroid.upload.Suri
 import com.ubergeek42.WeechatAndroid.upload.Target
+import com.ubergeek42.WeechatAndroid.upload.TextShareObject
 import com.ubergeek42.WeechatAndroid.upload.Upload.CancelledException
 import com.ubergeek42.WeechatAndroid.upload.UploadManager
 import com.ubergeek42.WeechatAndroid.upload.UploadObserver
+import com.ubergeek42.WeechatAndroid.upload.UrisShareObject
 import com.ubergeek42.WeechatAndroid.upload.WRITE_PERMISSION_REQUEST_FOR_CAMERA
 import com.ubergeek42.WeechatAndroid.upload.chooseFiles
 import com.ubergeek42.WeechatAndroid.upload.getShareObjectFromIntent
@@ -221,6 +224,9 @@ class BufferFragment : Fragment(), BufferEye {
                 }
             }
         }
+
+        ui.chatInput.setOnDragListener(onDragListener)
+        ui.root.setOnDragListener(onDragListener)
 
         ui.scrollToBottomFab.setOnClickListener {
             ui.chatLines.jumpThenSmoothScroll(linesAdapter!!.itemCount - 1)
@@ -971,6 +977,37 @@ class BufferFragment : Fragment(), BufferEye {
             }
             pendingInputs.remove(buffer.fullName)
         }
+    }
+
+    // It is possible to use OnReceiveContentListener instead of this.
+    // This allows showing some drag and drop indications,
+    // as well as more explicit and possibly simpler permission handling.
+    // We indicate that we handle `ACTION_DRAG_STARTED`, else `ACTION_DROP` is not received;
+    // We indicate that we don't handle other events
+    // in order to allow cursor movement in the input field while dragging.
+    private val onDragListener = View.OnDragListener { _, event ->
+        if (event.action == DragEvent.ACTION_DRAG_STARTED) return@OnDragListener true
+        if (event.action != DragEvent.ACTION_DROP) return@OnDragListener false
+
+        ulet(activity, ui, event.clipData) { activity, ui, clipData ->
+            val uris = (0..<clipData.itemCount).mapNotNull { clipData.getItemAt(it).uri }
+
+            if (uris.isNotEmpty()) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    activity.requestDragAndDropPermissions(event)
+                }
+
+                suppress<Exception>(showToast = true) {
+                    UrisShareObject.fromUris(uris).insert(ui.chatInput, InsertAt.CURRENT_POSITION)
+                }
+            } else if (clipData.itemCount > 0) {
+                clipData.getItemAt(0).text?.let { text ->
+                    TextShareObject(text).insert(ui.chatInput, InsertAt.CURRENT_POSITION)
+                }
+            }
+        }
+
+        true
     }
 }
 

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/upload/MediaAcceptingEditText.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/upload/MediaAcceptingEditText.kt
@@ -67,8 +67,10 @@ class MediaAcceptingEditText : ActionEditText {
         text?.let {
             for (span in it.getSpans(0, it.length, ShareSpan::class.java)) {
                 span.suri.httpUri?.let { httpUri ->
-                    it.replace(it.getSpanStart(span), it.getSpanEnd(span), httpUri)
+                    val pos = it.getSpanStart(span)
+                    it.replace(pos, it.getSpanEnd(span), "")
                     it.removeSpan(span)
+                    insertAddingSpacesAsNeeded(pos, httpUri)
                 }
             }
         }

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/upload/MediaAcceptingEditText.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/upload/MediaAcceptingEditText.kt
@@ -5,16 +5,18 @@ import android.net.Uri
 import android.os.Build
 import android.os.Parcel
 import android.os.Parcelable
-import android.text.Spanned
 import android.util.AttributeSet
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
 import androidx.core.view.inputmethod.EditorInfoCompat
 import androidx.core.view.inputmethod.InputConnectionCompat
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import com.ubergeek42.WeechatAndroid.utils.ActionEditText
 import com.ubergeek42.WeechatAndroid.utils.Toaster.Companion.ErrorToast
 import com.ubergeek42.cats.Kitty
 import com.ubergeek42.cats.Root
+import kotlinx.coroutines.launch
 
 
 class MediaAcceptingEditText : ActionEditText {
@@ -109,7 +111,7 @@ class MediaAcceptingEditText : ActionEditText {
     ///////////////////////////////////////////////////////////////////////////////// save & restore
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
-    class ShareSpanInfo(val uri: Uri, val start: Int, val end: Int)
+    data class ShareSpanInfo(val uri: Uri, val start: Int, val end: Int)
 
     override fun onSaveInstanceState(): Parcelable? {
         return SavedState(super.onSaveInstanceState()).apply {
@@ -129,14 +131,13 @@ class MediaAcceptingEditText : ActionEditText {
             // if so, make sure we don't create them twice
             if (state.shareSpans.isEmpty() || text == null || hasShareSpans()) return
 
-            state.shareSpans.forEach {
-                suppress<Exception>(showToast = true) {
-                    val suri = Suri.fromUri(it.uri)
-                    getThumbnailAndThen(context, it.uri) { bitmap ->
-                        val span = if (bitmap != NO_BITMAP)
-                            BitmapShareSpan(suri, bitmap) else NonBitmapShareSpan(suri)
+            findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
+                state.shareSpans.forEach { (uri, start, end) ->
+                    launch {
                         suppress<Exception>(showToast = true) {
-                            text?.setSpan(span, it.start, it.end, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                            val suri = Suri.fromUri(uri)
+                            val thumbnailSpannable = makeThumbnailSpannable(context, suri)
+                            text?.replace(start, end, thumbnailSpannable)
                         }
                     }
                 }

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/upload/ShareObject.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/upload/ShareObject.kt
@@ -121,10 +121,12 @@ val NO_BITMAP: Bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ALPHA_8)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-
 @MainThread fun EditText.insertAddingSpacesAsNeeded(insertAt: InsertAt, word: CharSequence) {
     val pos = if (insertAt == InsertAt.CURRENT_POSITION) selectionEnd else text.length
+    insertAddingSpacesAsNeeded(pos, word)
+}
 
+@MainThread fun EditText.insertAddingSpacesAsNeeded(pos: Int, word: CharSequence) {
     val wordStartsWithSpace = word.firstOrNull() == ' '
     val wordEndsWithSpace = word.lastOrNull() == ' '
     val    spaceBeforeInsertLocation = pos > 0 && text[pos - 1] == ' '

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/upload/ShareObject.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/upload/ShareObject.kt
@@ -102,8 +102,12 @@ fun getThumbnailAndThen(context: Context, uri: Uri, then: (bitmap: Bitmap) -> Un
                         then(bitmap)
                     }
 
+                    // The request seems to be attempted once again on minimizing/restoring the app.
+                    // To avoid that, clear target soon, but not on current thread--the library doesn't allow it.
+                    // See https://github.com/bumptech/glide/issues/4125
                     @MainThread override fun onLoadFailed(errorDrawable: Drawable?) {
                         then(NO_BITMAP)
+                        main { Glide.with(context).clear(this) }
                     }
 
                     override fun onLoadCleared(placeholder: Drawable?) {

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/upload/ShareObject.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/upload/ShareObject.kt
@@ -8,6 +8,8 @@ import android.net.Uri
 import android.text.*
 import android.widget.EditText
 import androidx.annotation.MainThread
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.MultiTransformation
 import com.bumptech.glide.load.engine.DiskCacheStrategy
@@ -16,8 +18,15 @@ import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition
 import com.ubergeek42.WeechatAndroid.media.Config
 import com.ubergeek42.WeechatAndroid.media.WAGlideModule.isContextValidForGlide
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import java.io.FileNotFoundException
 import java.io.IOException
+import kotlin.coroutines.resume
 
 
 enum class InsertAt {
@@ -45,32 +54,20 @@ const val PLACEHOLDER_TEXT = "\u00a0"
 open class UrisShareObject(
     private val suris: List<Suri>
 ) : ShareObject {
-    protected val bitmaps: Array<Bitmap?> = arrayOfNulls(suris.size)
-
     override fun insert(editText: EditText, insertAt: InsertAt) {
-        val context = editText.context
-        getAllImagesAndThen(context) {
-            for (i in suris.indices) {
-                editText.insertAddingSpacesAsNeeded(insertAt, makeImageSpanned(i))
-            }
+        editText.findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
+            insertAsync(editText, insertAt)
         }
     }
 
-    open fun getAllImagesAndThen(context: Context, then: () -> Unit) {
-        suris.forEachIndexed { i, suri ->
-            getThumbnailAndThen(context, suri.uri) { bitmap ->
-                bitmaps[i] = bitmap
-                if (bitmaps.all { it != null }) then()
-            }
+    suspend fun insertAsync(editText: EditText, insertAt: InsertAt) {
+        val thumbnailSpannables = coroutineScope {
+            suris.map { async { makeThumbnailSpannable(editText.context, it) } }.awaitAll()
         }
-    }
 
-    private fun makeImageSpanned(i: Int) : Spanned {
-        val spanned = SpannableString(PLACEHOLDER_TEXT)
-        val imageSpan = if (bitmaps[i] != NO_BITMAP)
-                BitmapShareSpan(suris[i], bitmaps[i]!!) else NonBitmapShareSpan(suris[i])
-        spanned.setSpan(imageSpan, 0, spanned.length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
-        return spanned
+        thumbnailSpannables.forEach { thumbnailSpannable ->
+            editText.insertAddingSpacesAsNeeded(insertAt, thumbnailSpannable)
+        }
     }
 
     companion object {
@@ -81,15 +78,23 @@ open class UrisShareObject(
     }
 }
 
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+suspend fun makeThumbnailSpannable(context: Context, suri: Suri): Spannable {
+    val bitmapOrNull = getBitmapOrNull(context, suri.uri)
+    val span = if (bitmapOrNull != null) BitmapShareSpan(suri, bitmapOrNull) else NonBitmapShareSpan(suri)
+
+    return SpannableString(PLACEHOLDER_TEXT).apply {
+        setSpan(span, 0, length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+    }
+}
 
 // this starts the upload in a worker thread and exits immediately.
 // target callbacks will be called on the main thread
-fun getThumbnailAndThen(context: Context, uri: Uri, then: (bitmap: Bitmap) -> Unit) {
-    if (isContextValidForGlide(context)) {
-        Glide.with(context)
+suspend fun getBitmapOrNull(context: Context, uri: Uri): Bitmap? =
+    suspendCancellableCoroutine { continuation ->
+        if (isContextValidForGlide(context)) {
+            Glide.with(context)
                 .asBitmap()
                 .diskCacheStrategy(DiskCacheStrategy.RESOURCE)
                 .transform(MultiTransformation(
@@ -99,14 +104,14 @@ fun getThumbnailAndThen(context: Context, uri: Uri, then: (bitmap: Bitmap) -> Un
                 .load(uri)
                 .into(object : CustomTarget<Bitmap>(THUMBNAIL_MAX_WIDTH, THUMBNAIL_MAX_HEIGHT) {
                     @MainThread override fun onResourceReady(bitmap: Bitmap, transition: Transition<in Bitmap>?) {
-                        then(bitmap)
+                        continuation.resume(bitmap)
                     }
 
                     // The request seems to be attempted once again on minimizing/restoring the app.
                     // To avoid that, clear target soon, but not on current thread--the library doesn't allow it.
                     // See https://github.com/bumptech/glide/issues/4125
                     @MainThread override fun onLoadFailed(errorDrawable: Drawable?) {
-                        then(NO_BITMAP)
+                        continuation.resume(null)
                         main { Glide.with(context).clear(this) }
                     }
 
@@ -114,10 +119,8 @@ fun getThumbnailAndThen(context: Context, uri: Uri, then: (bitmap: Bitmap) -> Un
                         // this shouldn't happen
                     }
                 })
+        }
     }
-}
-
-val NO_BITMAP: Bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ALPHA_8)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -167,9 +170,7 @@ fun preloadThumbnailsForIntent(intent: Intent) {
         else -> null
     }
 
-    if (uris != null) {
-        suppress<Exception> {
-            UrisShareObject.fromUris(uris).getAllImagesAndThen(applicationContext) {}
-        }
+    uris?.forEach { uri ->
+        GlobalScope.launch { getBitmapOrNull(applicationContext, uri) }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle:7.3.1")
         classpath("org.aspectj:aspectjtools:1.9.9.1")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.20")
         classpath("org.jetbrains.kotlin:kotlin-serialization:1.7.0")
     }
 }


### PR DESCRIPTION
See individual commits.

For drag n drop, the entire buffer fragment acts like a drop target.

I'm not sure whether or not we need drag-n-drop indicators, like the ones you see in Gmail. One one hand, we normally only show a single buffer. On the other, it might be somewhat useful to indicate that the buffer list or the title bar are not targets for dropping files. I decided to not do any indicators because I am lazy and who even drags and drops files on Android anyway.