### PR TITLE
Handle _buffer_line_data_changed

### DIFF
--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Buffer.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Buffer.kt
@@ -218,6 +218,14 @@ class Buffer @WorkerThread constructor(
         }
    }
 
+    @WorkerThread fun replaceLine(line: Line) {
+        if (isOpen) line.ensureSpannable()
+
+        synchronized(this) {
+            lines.replaceLine(line)
+        }
+    }
+
     @WorkerThread fun addLineBottom(line: Line) {
         if (isOpen) line.ensureSpannable()
 
@@ -435,7 +443,7 @@ class Buffer @WorkerThread constructor(
 
     @WorkerThread @Synchronized fun onNicksListed(newNicks: Collection<Nick>) {
         nicks.replaceNicks(newNicks)
-        nicks.sortNicksByLines(lines.descendingFilteredIterator)
+        nicks.sortNicksByNamesThatSpokeLast(lines.namesThatSpokeLast)
     }
 
     @WorkerThread private fun notifyNicklistChanged() {

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Buffer.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Buffer.kt
@@ -17,7 +17,6 @@ import com.ubergeek42.WeechatAndroid.utils.updatable
 import com.ubergeek42.cats.Cat
 import com.ubergeek42.cats.Kitty
 import com.ubergeek42.cats.Root
-import java.util.*
 
 class Buffer @WorkerThread constructor(
     @JvmField val pointer: Long,
@@ -209,7 +208,7 @@ class Buffer @WorkerThread constructor(
     /////////////////////////////////////////////////////////////// stuff called by message handlers
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
-    @WorkerThread @Synchronized fun replaceLines(newLines: Collection<Line>) {
+    @WorkerThread fun replaceLines(newLines: Collection<Line>) {
         if (isOpen) {
             newLines.forEach { it.ensureSpannable() }
         }
@@ -363,6 +362,17 @@ class Buffer @WorkerThread constructor(
 
     @WorkerThread fun onLinesListed() {
         synchronized(this) { lines.onLinesListed() }
+        bufferEyes.forEach { it.onLinesListed() }
+    }
+
+    @WorkerThread fun onLinesCleared() {
+        synchronized(this) {
+            lines = Lines().apply {
+                status = Lines.Status.EverythingFetched
+                title = lines.title
+            }
+            resetUnreadsAndHighlights()
+        }
         bufferEyes.forEach { it.onLinesListed() }
     }
 

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/BufferList.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/BufferList.kt
@@ -388,6 +388,12 @@ object BufferList {
             }
         }
 
+        add("_buffer_cleared") { obj, _ ->
+            obj.forEachExistingBuffer { _, buffer ->
+                buffer.onLinesCleared()
+            }
+        }
+
         return handlers
     }
 

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/BufferList.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/BufferList.kt
@@ -395,6 +395,8 @@ object BufferList {
         }
 
         add("_buffer_line_data_changed") { obj, _ ->
+            if (!P.handleBufferLineDataChanged) return@add
+
             obj.forEach { entry ->
                 val spec = LineSpec(entry)
                 findByPointer(spec.bufferPointer)?.let { buffer ->

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/BufferList.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/BufferList.kt
@@ -394,6 +394,16 @@ object BufferList {
             }
         }
 
+        add("_buffer_line_data_changed") { obj, _ ->
+            obj.forEach { entry ->
+                val spec = LineSpec(entry)
+                findByPointer(spec.bufferPointer)?.let { buffer ->
+                    buffer.replaceLine(spec.toLine())
+                    buffer.onLinesListed()
+                }
+            }
+        }
+
         return handlers
     }
 

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Line.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Line.kt
@@ -21,7 +21,7 @@ import com.ubergeek42.weechat.Color
 import com.ubergeek42.weechat.ColorScheme
 
 
-open class Line constructor(
+open class Line(
     @JvmField val pointer: Long,
     @JvmField val type: LineSpec.Type,
     @JvmField val timestamp: Long,
@@ -102,6 +102,14 @@ open class Line constructor(
 
     val timestampedIrcLikeString: String get() =
             timestampString?.let { timestamp -> "$timestamp $ircLikeString" } ?: ircLikeString
+
+    fun visuallyEqualsTo(other: Line) =
+        type == other.type &&
+        timestamp == other.timestamp &&
+        rawPrefix == other.rawPrefix &&
+        rawMessage == other.rawMessage &&
+        isHighlighted == other.isHighlighted &&
+        displayAs == other.displayAs
 
     override fun toString() = "Line(${pointer.as0x}): $ircLikeString)"
 }

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Nicks.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Nicks.kt
@@ -5,7 +5,9 @@ package com.ubergeek42.WeechatAndroid.relay
 import com.ubergeek42.WeechatAndroid.utils.removeChars
 import com.ubergeek42.WeechatAndroid.utils.removeFirst
 import com.ubergeek42.WeechatAndroid.utils.replaceFirstWith
-import java.util.*
+import java.util.Collections
+import java.util.LinkedList
+import java.util.Locale
 
 
 // this class is supposed to be synchronized by Buffer
@@ -64,15 +66,12 @@ internal class Nicks {
         if (nick != null) nicks.addFirst(nick)
     }
 
-    fun sortNicksByLines(iterator: Iterator<Line>) {
+    fun sortNicksByNamesThatSpokeLast(namesThatSpokeLast: Iterator<String>) {
         val nameToPosition = mutableMapOf<String, Int>()
 
-        iterator.forEach { line ->
-            if (line.type === LineSpec.Type.IncomingMessage) {
-                val name = line.nick
-                if (name != null && !nameToPosition.containsKey(name)) {
-                    nameToPosition[name] = nameToPosition.size
-                }
+        namesThatSpokeLast.forEach { name ->
+            if (!nameToPosition.containsKey(name)) {
+                nameToPosition[name] = nameToPosition.size
             }
         }
 

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Spec.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/relay/Spec.kt
@@ -5,6 +5,7 @@ package com.ubergeek42.WeechatAndroid.relay
 import com.ubergeek42.WeechatAndroid.R
 import com.ubergeek42.WeechatAndroid.service.P
 import com.ubergeek42.weechat.relay.connection.Handshake
+import com.ubergeek42.weechat.relay.connection.Handshake.Companion.weechatVersion
 import com.ubergeek42.weechat.relay.connection.find
 import com.ubergeek42.weechat.relay.protocol.Hashtable
 import com.ubergeek42.weechat.relay.protocol.HdataEntry
@@ -108,23 +109,23 @@ enum class Notify(val value: Int) {
 
 @JvmInline value class LastLinesSpec(val entry: HdataEntry) {
     inline val bufferPointer: Long get() = entry.getPointerLong("buffer")
-    inline val linePointer: Long get() = entry.pointerLong
+    inline val linePointer: Long get() = if (weechatVersion >= 0x4040000) entry.getInt("id").toLong() else entry.pointerLong
     inline val visible: Boolean get() = entry.getChar("displayed") == 1.toChar()
 
     companion object {
         const val request = "(last_lines) hdata " +
-                "buffer:gui_buffers(*)/own_lines/last_line(-25)/data buffer,displayed"
+                "buffer:gui_buffers(*)/own_lines/last_line(-25)/data id,buffer,displayed"
     }
 }
 
 
 @JvmInline value class LastReadLineSpec(val entry: HdataEntry) {
     inline val bufferPointer: Long get() = entry.getPointerLong("buffer")
-    inline val linePointer: Long get() = entry.pointerLong
+    inline val linePointer: Long get() = if (weechatVersion >= 0x4040000) entry.getInt("id").toLong() else entry.pointerLong
 
     companion object {
         const val request = "(last_read_lines) hdata " +
-                "buffer:gui_buffers(*)/own_lines/last_read_line/data buffer"
+                "buffer:gui_buffers(*)/own_lines/last_read_line/data id,buffer"
     }
 }
 
@@ -154,7 +155,7 @@ class HotlistSpec(entry: HdataEntry) {
 @JvmInline value class LineSpec(val entry: HdataEntry) {
     inline val bufferPointer: Long get() = entry.getPointerLong("buffer")
 
-    inline val pointer: Long get() = entry.pointerLong
+    inline val pointer: Long get() = if (weechatVersion >= 0x4040000) entry.getInt("id").toLong() else entry.pointerLong
     inline val timestamp: Long get() = entry.getItem("date").asTime().time
     inline val prefix: String? get() = entry.getStringOrNull("prefix")
     inline val message: String? get() = entry.getStringOrNull("message")
@@ -170,7 +171,7 @@ class HotlistSpec(entry: HdataEntry) {
     companion object {
         fun makeLastLinesRequest(id: String, pointer: Long, numberOfLines: Int) =
                 "($id) hdata buffer:${pointer.as0x}/own_lines/last_line(-$numberOfLines)/data " +
-                "date,displayed,prefix,message,highlight,notify,tags_array"
+                "id,date,displayed,prefix,message,highlight,notify,tags_array"
     }
 
     fun toLine(): Line {

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/service/P.java
@@ -247,6 +247,7 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
     static long pingIdleTime, pingTimeout;
     public static int lineIncrement;
     public static int searchLineIncrement;
+    public static boolean handleBufferLineDataChanged;
 
     static String printableHost;
     static boolean connectionSurelyPossibleWithCurrentPreferences;
@@ -275,6 +276,7 @@ public class P implements SharedPreferences.OnSharedPreferenceChangeListener{
 
         lineIncrement = Integer.parseInt(getString(PREF_LINE_INCREMENT, PREF_LINE_INCREMENT_D));
         searchLineIncrement = Integer.parseInt(getString(PREF_SEARCH_LINE_INCREMENT, PREF_SEARCH_LINE_INCREMENT_D));
+        handleBufferLineDataChanged = p.getBoolean(PREF_HANDLE_BUFFER_LINE_DATA_CHANGED, PREF_HANDLE_BUFFER_LINE_DATA_CHANGED_D);
 
         reconnect = p.getBoolean(PREF_RECONNECT, PREF_RECONNECT_D);
         optimizeTraffic = p.getBoolean(PREF_OPTIMIZE_TRAFFIC, PREF_OPTIMIZE_TRAFFIC_D);

--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/Constants.java
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/utils/Constants.java
@@ -63,6 +63,8 @@ public class Constants {
     final public static String PREF_LINE_INCREMENT_D = "300";
     final static public String PREF_SEARCH_LINE_INCREMENT = "line_number_to_request_when_starting_search";
     final static public String PREF_SEARCH_LINE_INCREMENT_D = "4097";
+    final static public String PREF_HANDLE_BUFFER_LINE_DATA_CHANGED = "handle_buffer_line_data_changed";
+    final static public Boolean PREF_HANDLE_BUFFER_LINE_DATA_CHANGED_D = true;
     final static public String PREF_RECONNECT = "reconnect";
     final public static boolean PREF_RECONNECT_D = true;
     final static public String PREF_BOOT_CONNECT = "boot_connect";

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -539,6 +539,11 @@
         Also note that due to WeeChat’s limitations
         the app has to re-fetch all lines every times it requests more lines.</string>
 
+    <string name="pref__connection__synchronization__handle_buffer_line_data_changed">
+        Handle line changes</string>
+    <string name="pref__connection__synchronization__handle_buffer_line_data_changed_summary">
+        In rare circumstances displaying line changes may lead to jerky animation</string>
+
     <!-- ############################## connection: miscellaneous ############################## -->
 
     <string name="pref__connection__misc_group">Miscellaneous</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -151,6 +151,11 @@
                     android:summary="@string/pref__connection__synchronization_help"
                     android:persistent="false"
                     android:selectable="false" />
+                <CheckBoxPreference
+                    android:key="handle_buffer_line_data_changed"
+                    android:title="@string/pref__connection__synchronization__handle_buffer_line_data_changed"
+                    android:summary="@string/pref__connection__synchronization__handle_buffer_line_data_changed_summary"
+                    android:defaultValue="true" />
             </PreferenceScreen>
         </PreferenceCategory>
 


### PR DESCRIPTION
Adds support for `_buffer_line_data_changed`. Also provides the stable line ID when available and uses this when diffing.

~Open question: currently this animates a line change as `Animation.NewLinesFetched`. Is that desirable? Should there be no animation? Some other animation?~ Line edits will not interrupt any running animation, but will also not trigger an animation of their own. Good enough for now?