### PR TITLE
Tint server buffer names in the buffer list

### DIFF
--- a/app/src/main/java/com/ubergeek42/WeechatAndroid/adapters/BufferListAdapter.kt
+++ b/app/src/main/java/com/ubergeek42/WeechatAndroid/adapters/BufferListAdapter.kt
@@ -15,12 +15,16 @@ package com.ubergeek42.WeechatAndroid.adapters
 
 import android.content.Context
 import android.text.Spannable
+import android.text.SpannableString
+import android.text.Spanned
+import android.text.style.ForegroundColorSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.annotation.AnyThread
 import androidx.annotation.MainThread
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
@@ -72,7 +76,17 @@ class BufferListAdapter(
             val important = highlights > 0 || unreads > 0 && buffer.type == BufferSpec.Type.Private
             ui.container.setBackgroundResource(if (important) buffer.type.hotColorRes else buffer.type.colorRes)
             ui.openIndicator.visibility = if (buffer.isOpen) View.VISIBLE else View.GONE
-            ui.buffer.text = buffer.printable
+
+            // server buffers (e.g. "freenode", "libera") have no explicit type,
+            // so they fall into Type.Other -- tint their name to set them apart
+            // from regular channel/private buffer rows in the list
+            val printable = buffer.printable
+            ui.buffer.text = if (buffer.type == BufferSpec.Type.Other && printable != null) {
+                SpannableString(printable).apply {
+                    val color = ContextCompat.getColor(itemView.context, R.color.bufferListServerName)
+                    setSpan(ForegroundColorSpan(color), 0, length, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+                }
+            } else printable
 
             fun TextView.applyNumber(number: Int) {
                 if (number > 0) {

--- a/app/src/main/res/values-night/colors.xml
+++ b/app/src/main/res/values-night/colors.xml
@@ -20,6 +20,7 @@
     <color name="bufferListChannelHot">#aa596c7d</color>
     <color name="bufferListPrivate">#aa57474f</color>
     <color name="bufferListPrivateHot">#aa735e69</color>
+    <color name="bufferListServerName">@color/accent</color>
 
     <color name="warmShade">#59ffffff</color>
     <color name="warmBackground">#29000000</color>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -19,6 +19,7 @@
     <color name="bufferListPrivate">#44570022</color>
     <color name="bufferListPrivateHot">#44e30052</color>
     <color name="bufferListOpenIndicator">@color/textColor</color>
+    <color name="bufferListServerName">@color/accent</color>
 
     <color name="warmShade">#66ffffff</color>
     <color name="warmBackground">#11000000</color>


### PR DESCRIPTION
## Summary
- Server buffers (the top-level IRC-network entry, e.g. "freenode") don't carry an explicit WeeChat buffer `type`, so they fall into `BufferSpec.Type.Other` alongside things like the core `weechat` buffer.
- This gives server-buffer rows a distinct accent-colored name tint in the drawer buffer list, so they stand out visually from regular channel/private buffer rows.
- Uses the existing `@color/accent` for both light and dark themes via a new `bufferListServerName` color resource.

## Note
Since the app has no separate concept of a "server connection name" distinct from the server's own WeeChat buffer, this targets `BufferSpec.Type.Other` as the closest available proxy — which also covers the core `weechat` buffer (it gets the same tint). Happy to adjust the scoping if there's a preferred way to distinguish those.

## Test plan
- [ ] Verified visually in light and dark theme that server-type buffer rows (and the `weechat` core buffer) show the tinted name while channel/private rows are unaffected
- [ ] Confirmed buffer number prefix styling (superscript/small spans) is preserved on tinted rows